### PR TITLE
{group,resource}: prevent diff on reviewer

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -86,7 +86,7 @@ resource "opal_group" "google_group_example" {
 - `require_manager_approval` (Boolean) Require the requester's manager's approval for requests to this group.
 - `require_mfa_to_approve` (Boolean) Require that reviewers MFA to approve requests for this group.
 - `require_support_ticket` (Boolean) Require that requesters attach a support ticket to requests for this group.
-- `reviewer` (Block List) A required reviewer for this group. If none are specified. (see [below for nested schema](#nestedblock--reviewer))
+- `reviewer` (Block Set) A required reviewer for this group. If none are specified, then the admin owner will be used. (see [below for nested schema](#nestedblock--reviewer))
 - `visibility` (String) The visibility level of the group, i.e. LIMITED or GLOBAL.
 - `visibility_group` (Block List) The groups that can see this group when visibility is limited. If not specified, only users with direct access can see this resource when visibility is set to LIMITED. (see [below for nested schema](#nestedblock--visibility_group))
 

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -78,7 +78,7 @@ resource "opal_resource" "github_repo_example" {
 
 ### Required
 
-- `admin_owner_id` (String) The admin owner ID for this resource. By default, this is set to the application admin owner.
+- `admin_owner_id` (String) The admin owner ID for this resource.
 - `app_id` (String) The ID of the app integration that provides the resource. You can get this value from the URL of the app in the Opal web app.
 - `name` (String) The name of the resource.
 - `resource_type` (String) The type of the resource, i.e. AWS_EC2_INSTANCE.
@@ -94,7 +94,7 @@ resource "opal_resource" "github_repo_example" {
 - `require_mfa_to_approve` (Boolean) Require that reviewers MFA to approve requests for this resource.
 - `require_mfa_to_connect` (Boolean) Require that users MFA to connect to this resource. Only applicable for resources where a session can be started from Opal (i.e. AWS RDS database)
 - `require_support_ticket` (Boolean) Require that requesters attach a support ticket to requests for this resource.
-- `reviewer` (Block List) A required reviewer for this resource. If none are specified, then the admin owner will be used. (see [below for nested schema](#nestedblock--reviewer))
+- `reviewer` (Block Set) A required reviewer for this resource. If none are specified, then the admin owner will be used. (see [below for nested schema](#nestedblock--reviewer))
 - `visibility` (String) The visibility level of the resource, i.e. LIMITED or GLOBAL.
 - `visibility_group` (Block List) The groups that can see this resource when visibility is limited. If not specified, only admins and users with direct access can see this resource when visibility is set to LIMITED. (see [below for nested schema](#nestedblock--visibility_group))
 

--- a/opal/resource.go
+++ b/opal/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"reflect"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -135,9 +136,10 @@ func resourceResource() *schema.Resource {
 				},
 			},
 			"reviewer": {
-				Description: "A required reviewer for this resource. If none are specified, then the admin owner will be used.",
-				Type:        schema.TypeList,
-				Optional:    true,
+				Description:      "A required reviewer for this resource. If none are specified, then the admin owner will be used.",
+				Type:             schema.TypeSet,
+				Optional:         true,
+				DiffSuppressFunc: ignoreReviewerDefaultValue,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -281,7 +283,16 @@ func resourceResourceUpdateVisibility(ctx context.Context, d *schema.ResourceDat
 }
 
 func resourceResourceUpdateReviewers(ctx context.Context, d *schema.ResourceData, client *opal.APIClient, reviewersI any) diag.Diagnostics {
-	rawReviewers := reviewersI.([]any)
+	// reviewersI could be a schema.Set from terraform or our own constructed slice.
+	var rawReviewers []any
+	switch reviewersI := reviewersI.(type) {
+	case []any:
+		rawReviewers = reviewersI
+	case *schema.Set:
+		rawReviewers = reviewersI.List()
+	default:
+		return diag.Errorf("bad type passed: %v", reflect.TypeOf(reviewersI))
+	}
 	reviewerIds := make([]string, 0, len(rawReviewers))
 	for _, rawReviewer := range rawReviewers {
 		reviewer := rawReviewer.(map[string]any)

--- a/opal/verify.go
+++ b/opal/verify.go
@@ -1,0 +1,27 @@
+package opal
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+// ignoreReviewerDefaultValue is a DiffSuppressFunc that lets us correctly
+// handle a missing, optional reviewer block.
+func ignoreReviewerDefaultValue(k, oldValue, newValue string, d *schema.ResourceData) bool {
+	// If the list of reviewers went from 0 to 1, we don't want to force a diff iff
+	// the oldValue is the same as the admin_owner_id. This covers the case where
+	// the user omits the reviewer block and lets the API compute the value. Without
+	// this code, there will be a permanent (no-op) diff where terraform constantly
+	// tries to delete the reviewer.
+	if oldValue == "1" && newValue == "0" {
+		// The case where we go from 1 -> 0 is where the length of the set goes from
+		// 1 to 0. To actually check if we're in the case outlined above, we need to
+		// query for the actual values (instead of the lengths).
+		oldI, _ := d.GetChange("reviewer")
+		old := oldI.(*schema.Set)
+		// This should be case to index into because the schema validation would have complained
+		// before we get here.
+		if old.List()[0].(map[string]any)["id"] == d.Get("admin_owner_id") {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/opalsecurity/terraform-provider-opal/commit/909aa110a39091a509e55f1bf3f487ab9f1b8246 where a permanent diff shows up. We can't simply mark the field as computed because terraform doesn't let you delete blocks after they're set with computed values.

There is still a weirdness with the state that I documented in the test. In the cases where the reviewer block is unset, the reviewer id is still in the set when deleting a ` reviewer {}` block, which is different from omitting the `reviewer {}` block on creation (reviewer id not in state). I think this is mostly not a problem because I can't think of compelling cases for referring to the reviewer of a resource/group (i.e. `opal_group.reviewer.0.id` is a weird reference?). This should be strictly better behavior than the current code.