### PR TITLE
{group,resource}: fix bug where auto approve on create did not work

### DIFF
--- a/opal/group.go
+++ b/opal/group.go
@@ -236,12 +236,9 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m any) dia
 		if diag := resourceGroupUpdateReviewers(ctx, d, client, reviewersI); diag != nil {
 			return diag
 		}
-	} else if adminOwnerIDOk {
-		// If the admin owner was set during creation, we should also set
-		// the required reviewer to be the same so that it is consistent.
-		//
-		// Otherwise, if it's unset, the Opal API will automatically set it to
-		// the app owner.
+	} else if !autoApprovalOk || !(autoApprovalI.(bool)) {
+		// We should set the required reviewer to be the the admin owner (same behavior as the API) as
+		// long as we don't have auto approval.
 		if diag := resourceGroupUpdateReviewers(ctx, d, client, []any{map[string]any{"id": adminOwnerIDI}}); diag != nil {
 			return diag
 		}

--- a/opal/group_test.go
+++ b/opal/group_test.go
@@ -265,7 +265,7 @@ func TestAccGroup_SetOnCreate_AutoApproval(t *testing.T) {
 		CheckDestroy: testAccCheckGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupResourceWithReviewer(baseName, baseName, `
+				Config: testAccGroupResource(baseName, baseName, `
 auto_approval = true
 `),
 				Check: resource.ComposeTestCheckFunc(

--- a/opal/resource.go
+++ b/opal/resource.go
@@ -243,12 +243,9 @@ func resourceResourceCreate(ctx context.Context, d *schema.ResourceData, m any) 
 		if diag := resourceResourceUpdateReviewers(ctx, d, client, reviewersI); diag != nil {
 			return diag
 		}
-	} else if adminOwnerIDOk {
-		// If the admin owner was set during creation, we should also set
-		// the required reviewer to be the same so that it is consistent.
-		//
-		// Otherwise, if it's unset, the Opal API will automatically set it to
-		// the app owner.
+	} else if !autoApprovalOk || !(autoApprovalI.(bool)) {
+		// We should set the required reviewer to be the the admin owner (same behavior as the API) as
+		// long as we don't have auto approval.
 		if diag := resourceResourceUpdateReviewers(ctx, d, client, []any{map[string]any{"id": adminOwnerIDI}}); diag != nil {
 			return diag
 		}

--- a/opal/resource_test.go
+++ b/opal/resource_test.go
@@ -266,7 +266,7 @@ func TestAccResource_SetOnCreate_AutoApproval(t *testing.T) {
 		CheckDestroy: testAccCheckResourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceResourceWithReviewer(baseName, baseName, `
+				Config: testAccResourceResource(baseName, baseName, `
 auto_approval = true
 `),
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
After we changed this to always require admin owner id, the else if code block would always run. This was an undetected bug that lurked for a while until we changed the API to be better about keeping auto approval settings in sync with reviewers, which uncovered the buggy behavior.