### PR TITLE
Allow creation of owners without users

### DIFF
--- a/docs/resources/owner.md
+++ b/docs/resources/owner.md
@@ -31,13 +31,13 @@ resource "opal_owner" "security" {
 ### Required
 
 - `name` (String) The name of the owner.
-- `user` (Block List, Min: 1) The users for this owner. If an escalation period is set, the order of the users will determine the escalation order. (see [below for nested schema](#nestedblock--user))
 
 ### Optional
 
 - `access_request_escalation_period` (Number) The amount of time (in minutes) before the next reviewer is notified. By default, there is no escalation policy.
 - `description` (String) A description of the owner.
 - `reviewer_message_channel_id` (String) The id of the message_channel that incoming reviews should be posted to.
+- `user` (Block List) The users for this owner. If an escalation period is set, the order of the users will determine the escalation order. (see [below for nested schema](#nestedblock--user))
 
 ### Read-Only
 

--- a/opal/owner.go
+++ b/opal/owner.go
@@ -44,7 +44,7 @@ func resourceOwner() *schema.Resource {
 			"user": {
 				Description: "The users for this owner. If an escalation period is set, the order of the users will determine the escalation order.",
 				Type:        schema.TypeList,
-				Required:    true,
+				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/opal/owner_test.go
+++ b/opal/owner_test.go
@@ -76,8 +76,25 @@ func TestAccOwner_CRUD(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "user.1.id", knownUserID2), // Verify that adding a user works.
 				),
 			},
+			{
+				Config: testAccOwnerResourceNoUser(baseName, baseName+"_changed", ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(resourceName, "user.0.id"),
+					resource.TestCheckNoResourceAttr(resourceName, "user.1.id"),
+				),
+			},
 		},
 	})
+}
+
+func testAccOwnerResourceNoUser(tfName, name, additional string) string {
+	return fmt.Sprintf(`
+resource "opal_owner" "%s" {
+	name = "%s"
+
+	%s
+}
+`, tfName, name, additional)
 }
 
 func testAccOwnerResource(tfName, name, additional string) string {


### PR DESCRIPTION
Customers complained that they don't want to manage owner user lists from terraform. The use case here is that most likely they want to initialize a bunch of stuff 1 time and then manage it via the UI.

https://github.com/opalsecurity/opal/pull/4354 made a change on the API side to allow this. This makes the user attribute optional.

Verified that creating owners with no users works correctly 