### PR TITLE
Add ability to manage group resources 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
           OPAL_TEST_KNOWN_GITHUB_APP_TEAM_SLUG: ${{ secrets.OPAL_TEST_KNOWN_GITHUB_APP_TEAM_SLUG }}
           OPAL_TEST_KNOWN_OPAL_APP_ID: ${{ secrets.OPAL_TEST_KNOWN_OPAL_APP_ID }}
           OPAL_TEST_KNOWN_OPAL_APP_ADMIN_OWNER_ID: ${{ secrets.OPAL_TEST_KNOWN_OPAL_APP_ADMIN_OWNER_ID }}
+          OPAL_TEST_KNOWN_GITHUB_TEST_REPO_2_RESOURCE_ID: ${{ secrets.OPAL_TEST_KNOWN_GITHUB_TEST_REPO_2_RESOURCE_ID }}
       - name: Clean up test organization
         run: make sweep
         env:
@@ -54,6 +55,7 @@ jobs:
           OPAL_TEST_KNOWN_GITHUB_APP_TEAM_SLUG: ${{ secrets.OPAL_TEST_KNOWN_GITHUB_APP_TEAM_SLUG }}
           OPAL_TEST_KNOWN_OPAL_APP_ID: ${{ secrets.OPAL_TEST_KNOWN_OPAL_APP_ID }}
           OPAL_TEST_KNOWN_OPAL_APP_ADMIN_OWNER_ID: ${{ secrets.OPAL_TEST_KNOWN_OPAL_APP_ADMIN_OWNER_ID }}
+          OPAL_TEST_KNOWN_GITHUB_TEST_REPO_2_RESOURCE_ID: ${{ secrets.OPAL_TEST_KNOWN_GITHUB_TEST_REPO_2_RESOURCE_ID }}
       - name: Check for doc changes
         id: changes
         run: |

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -86,6 +86,7 @@ resource "opal_group" "google_group_example" {
 - `require_manager_approval` (Boolean) Require the requester's manager's approval for requests to this group.
 - `require_mfa_to_approve` (Boolean) Require that reviewers MFA to approve requests for this group.
 - `require_support_ticket` (Boolean) Require that requesters attach a support ticket to requests for this group.
+- `resource` (Block Set) A resource that members of the group get access to. (see [below for nested schema](#nestedblock--resource))
 - `reviewer` (Block Set) A required reviewer for this group. If none are specified, then the admin owner will be used. (see [below for nested schema](#nestedblock--reviewer))
 - `visibility` (String) The visibility level of the group, i.e. LIMITED or GLOBAL.
 - `visibility_group` (Block List) The groups that can see this group when visibility is limited. If not specified, only users with direct access can see this resource when visibility is set to LIMITED. (see [below for nested schema](#nestedblock--visibility_group))
@@ -161,6 +162,18 @@ Required:
 
 - `group_id` (String) The id of the Okta group.
 
+
+
+<a id="nestedblock--resource"></a>
+### Nested Schema for `resource`
+
+Required:
+
+- `id` (String) The ID of the resource.
+
+Optional:
+
+- `access_level_remote_id` (String) The access level remote id of the resource that this group gives access to.
 
 
 <a id="nestedblock--reviewer"></a>

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.22.0
-	github.com/opalsecurity/opal-go v1.0.11
+	github.com/opalsecurity/opal-go v1.0.12
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -286,6 +286,8 @@ github.com/opalsecurity/opal-go v1.0.9 h1:NlP3K15cpEYwtwHMnpp9TbzaLILUtcTm+OQax0
 github.com/opalsecurity/opal-go v1.0.9/go.mod h1:bzD4vZIbH+lKhsX8NJ5ISNU2Xgm2qzjj6O9G2ycj58c=
 github.com/opalsecurity/opal-go v1.0.11 h1:LC0/luUtNozHlUQnggc9i2+MwKqHU6ClE1PQ4HekEZ4=
 github.com/opalsecurity/opal-go v1.0.11/go.mod h1:bzD4vZIbH+lKhsX8NJ5ISNU2Xgm2qzjj6O9G2ycj58c=
+github.com/opalsecurity/opal-go v1.0.12 h1:ADpOuabaZ+pgxHdNt+qa9nN+ytRoxy3JkTak3Pt2RNI=
+github.com/opalsecurity/opal-go v1.0.12/go.mod h1:G7QQIi36kI3kiTl/Dp8AvLDNoui9jqFOSUthcZ0aof4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/opal/group.go
+++ b/opal/group.go
@@ -2,9 +2,7 @@ package opal
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"log"
 	"reflect"
 
 	"github.com/hashicorp/go-multierror"
@@ -347,12 +345,6 @@ func resourceGroupUpdateResources(ctx context.Context, d *schema.ResourceData, c
 	}
 
 	if _, err := client.GroupsApi.SetGroupResources(ctx, d.Id()).UpdateGroupResourcesInfo(updateInfo).Execute(); err != nil {
-		var gErr *opal.GenericOpenAPIError
-		if errors.As(err, &gErr) {
-			log.Println("error string", string(gErr.Body()))
-		} else {
-			log.Println("not", err)
-		}
 		return diagFromErr(ctx, err)
 	}
 	return nil
@@ -380,12 +372,6 @@ func resourceGroupUpdateReviewers(ctx context.Context, d *schema.ResourceData, c
 	})
 
 	if _, _, err := client.GroupsApi.SetGroupReviewers(ctx, d.Id()).ReviewerIDList(*opal.NewReviewerIDList(reviewerIds)).Execute(); err != nil {
-		var gErr *opal.GenericOpenAPIError
-		if errors.As(err, &gErr) {
-			log.Println("error string", string(gErr.Body()))
-		} else {
-			log.Println("not", err)
-		}
 		return diagFromErr(ctx, err)
 	}
 	return nil

--- a/opal/group.go
+++ b/opal/group.go
@@ -149,6 +149,25 @@ func resourceGroup() *schema.Resource {
 					},
 				},
 			},
+			"resource": {
+				Description: "A resource that members of the group get access to.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Description: "The ID of the resource.",
+							Type:        schema.TypeString,
+							Required:    true,
+						},
+						"access_level_remote_id": {
+							Description: "The access level remote id of the resource that this group gives access to.",
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -243,6 +262,11 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m any) dia
 			return diag
 		}
 	}
+	if _, ok := d.GetOk("resource"); ok {
+		if diag := resourceGroupUpdateResources(ctx, d, client); diag != nil {
+			return diag
+		}
+	}
 
 	if _, ok := d.GetOk("audit_message_channel"); ok {
 		if diag := resourceGroupUpdateAuditMessageChannels(ctx, d, client); diag != nil {
@@ -290,6 +314,47 @@ func resourceGroupUpdateAuditMessageChannels(ctx context.Context, d *schema.Reso
 		return diagFromErr(ctx, err)
 	}
 
+	return nil
+}
+
+func resourceGroupUpdateResources(ctx context.Context, d *schema.ResourceData, client *opal.APIClient) diag.Diagnostics {
+	var rawResources []any
+	if resourceI, ok := d.GetOk("resource"); ok {
+		rawResources = resourceI.(*schema.Set).List()
+	}
+
+	resourcesWithAccessLevel := make([]opal.ResourceWithAccessLevel, 0, len(rawResources))
+	for _, rawResource := range rawResources {
+		resource := rawResource.(map[string]any)
+		var accessLevelRemoteIDPtr *string
+		accessLevelRemoteID := resource["access_level_remote_id"].(string)
+		if accessLevelRemoteID != "" {
+			accessLevelRemoteIDPtr = &accessLevelRemoteID
+		}
+
+		resourcesWithAccessLevel = append(resourcesWithAccessLevel, opal.ResourceWithAccessLevel{
+			ResourceId:          resource["id"].(string),
+			AccessLevelRemoteId: accessLevelRemoteIDPtr,
+		})
+	}
+	tflog.Debug(ctx, "Setting group resources", map[string]any{
+		"id":        d.Id(),
+		"resources": resourcesWithAccessLevel,
+	})
+
+	updateInfo := opal.UpdateGroupResourcesInfo{
+		Resources: resourcesWithAccessLevel,
+	}
+
+	if _, err := client.GroupsApi.SetGroupResources(ctx, d.Id()).UpdateGroupResourcesInfo(updateInfo).Execute(); err != nil {
+		var gErr *opal.GenericOpenAPIError
+		if errors.As(err, &gErr) {
+			log.Println("error string", string(gErr.Body()))
+		} else {
+			log.Println("not", err)
+		}
+		return diagFromErr(ctx, err)
+	}
 	return nil
 }
 
@@ -472,6 +537,12 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, m any) dia
 			reviewers = reviewersBlock
 		}
 		if diag := resourceGroupUpdateReviewers(ctx, d, client, reviewers); diag != nil {
+			return diag
+		}
+	}
+
+	if d.HasChange("resource") {
+		if diag := resourceGroupUpdateResources(ctx, d, client); diag != nil {
 			return diag
 		}
 	}

--- a/opal/provider_test.go
+++ b/opal/provider_test.go
@@ -48,6 +48,10 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal(`OPAL_TEST_KNOWN_GITHUB_APP_TEAM_SLUG must be set for acceptance tests. This value is the name of the team you linked and must match what's in the test github org.`)
 	}
 
+	if v := os.Getenv("OPAL_TEST_KNOWN_GITHUB_TEST_REPO_2_RESOURCE_ID"); v == "" {
+		t.Fatal(`OPAL_TEST_KNOWN_GITHUB_TEST_REPO_2_RESOURCE_ID must be set for acceptance tests. This value is the Opal id of the test-repo-2 GitHub repo.`)
+	}
+
 	if os.Getenv("OPAL_TEST_KNOWN_USER_ID_1") == "" {
 		t.Fatal("OPAL_TEST_KNOWN_USER_ID_1 must be set for acceptance tests. You should get this value from any user in the test organization.")
 	}

--- a/opal/resource.go
+++ b/opal/resource.go
@@ -2,8 +2,6 @@ package opal
 
 import (
 	"context"
-	"errors"
-	"log"
 	"reflect"
 
 	"github.com/hashicorp/go-multierror"
@@ -301,12 +299,6 @@ func resourceResourceUpdateReviewers(ctx context.Context, d *schema.ResourceData
 	})
 
 	if _, _, err := client.ResourcesApi.SetResourceReviewers(ctx, d.Id()).ReviewerIDList(*opal.NewReviewerIDList(reviewerIds)).Execute(); err != nil {
-		var gErr *opal.GenericOpenAPIError
-		if errors.As(err, &gErr) {
-			log.Println("error string", string(gErr.Body()))
-		} else {
-			log.Println("not", err)
-		}
 		return diagFromErr(ctx, err)
 	}
 	return nil


### PR DESCRIPTION
Scale wants to manage group resource relationships in terraform. https://github.com/opalsecurity/opal/pull/4450 added the ability to our API and this PR now exposes the functionality to terraform. 

Added a test to validate the functionality works as expected.