### PR TITLE
Mark resource and group description as computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ resource "opal_group" "security" {
   }
 ```
 
+BUG FIXES:
+- prevents resource / groups created without description to have an immediate diff from default description generation
+
 ## v0.0.4
 - Fixes a bug for owner user parsing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.1
+
+BUG FIXES:
+- prevents resource / groups created without description to have an immediate diff from default description generation
+
 ## v1.0.0
 
 BREAKING CHANGES:
@@ -24,9 +29,6 @@ resource "opal_group" "security" {
     id = opal_on_call_schedule.security_oncall_rotation.id
   }
 ```
-
-BUG FIXES:
-- prevents resource / groups created without description to have an immediate diff from default description generation
 
 ## v0.0.4
 - Fixes a bug for owner user parsing

--- a/opal/group.go
+++ b/opal/group.go
@@ -42,6 +42,7 @@ func resourceGroup() *schema.Resource {
 				Description: "The description of the group.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"group_type": {
 				Description:  "The type of the group, i.e. GIT_HUB_TEAM.",

--- a/opal/resource.go
+++ b/opal/resource.go
@@ -48,6 +48,7 @@ func resourceResource() *schema.Resource {
 				Description: "The description of the resource.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"resource_type": {
 				Description:  "The type of the resource, i.e. AWS_EC2_INSTANCE.",


### PR DESCRIPTION
## Description of the change

Currently when creating resources / groups via Terraform, if the user does not provide a description, the first sync of the imported resource / group will put a default description in. 

This causes `terraform plan` to have a diff after creation. This avoids this.

NOTE: One issue with this solution is that the terraform provider SDK is not able to differentiate between not set at all and set to zero value. This means that it will not be possible to remove the description from Terraform once this change is made. 

See https://github.com/hashicorp/terraform-plugin-sdk/issues/1101

We can eventually mitigate this by migrating to a newly developed SDK https://github.com/hashicorp/terraform-plugin-framework


## Checklist

- [ ] I performed a self-review of my code
- [ ] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
