### PR TITLE
[OPAL-5704] Require explicit opt-in to manage group resource relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.0.2
+
+BUG FIXES:
+- adds a boolean flag to turn management of group <-> resource relationships off by default to avoid accidental access changes
+
+NEW FEATURES:
+- adds opal_owner data source
+
 ## v1.0.1
 
 BUG FIXES:

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -141,6 +141,7 @@ resource "opal_group" "google_group_example" {
 - `auto_approval` (Boolean) Automatically approve all requests for this group without review.
 - `description` (String) The description of the group.
 - `is_requestable` (Boolean) Allow users to create an access request for this group. By default, any group is requestable.
+- `manage_resources` (Boolean) Boolean flag to indicate if you intend to manage group <-> resource relationships via terraform.
 - `max_duration` (Number) The maximum duration for which this group can be requested (in minutes). By default, the max duration is indefinite access.
 - `on_call_schedule` (Block Set) An on call schedule for this group. (see [below for nested schema](#nestedblock--on_call_schedule))
 - `recommended_duration` (Number) The recommended duration for which the group should be requested (in minutes). Will be the default value in a request. Use -1 to set to indefinite.

--- a/opal/group.go
+++ b/opal/group.go
@@ -591,7 +591,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 		return diagFromErr(ctx, err)
 	}
 
-	groupResourcesI := make([]any, 0, len(reviewerStages))
+	groupResourcesI := make([]any, 0, len(groupResources.GroupResources))
 	for _, groupResource := range groupResources.GroupResources {
 		groupResourceI := map[string]any{
 			"id":                     groupResource.ResourceId,

--- a/opal/group.go
+++ b/opal/group.go
@@ -574,6 +574,21 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 	}
 	d.Set("reviewer_stage", reviewerStagesI)
 
+	groupResources, _, err := client.GroupsApi.GetGroupResources(ctx, group.GroupId).Execute()
+	if err != nil {
+		return diagFromErr(ctx, err)
+	}
+
+	groupResourcesI := make([]any, 0, len(reviewerStages))
+	for _, groupResource := range groupResources.GroupResources {
+		groupResourceI := map[string]any{
+			"id":                     groupResource.ResourceId,
+			"access_level_remote_id": groupResource.AccessLevel.AccessLevelRemoteId,
+		}
+		groupResourcesI = append(groupResourcesI, groupResourceI)
+	}
+	d.Set("resource", groupResourcesI)
+
 	return nil
 }
 

--- a/opal/group.go
+++ b/opal/group.go
@@ -176,10 +176,22 @@ func resourceGroup() *schema.Resource {
 					},
 				},
 			},
+			"manage_resources": {
+				Description: "Boolean flag to indicate if you intend to manage group <-> resource relationships via terraform.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+			},
 			"resource": {
 				Description: "A resource that members of the group get access to.",
 				Type:        schema.TypeSet,
 				Optional:    true,
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					if manage, ok := d.GetOk("manage_resources"); ok {
+						return !manage.(bool)
+					}
+					return true
+				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/opal/group_test.go
+++ b/opal/group_test.go
@@ -35,9 +35,10 @@ func TestAccGroup_Import(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"manage_resources"},
 			},
 		},
 	})
@@ -262,7 +263,16 @@ func TestAccGroup_Resource(t *testing.T) {
 				),
 			},
 			{
+				// Here we validate that without the manage_resources attribute the group resource does not get removed
+				// even when no group resources are provided
 				Config: testAccGroupResourceWithReviewer(baseName, baseName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", baseName),
+					resource.TestCheckResourceAttr(resourceName, "resource.#", "1"),
+				),
+			},
+			{
+				Config: testAccGroupResourceWithReviewer(baseName, baseName, "manage_resources=true"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", baseName),
 					resource.TestCheckResourceAttr(resourceName, "resource.#", "0"),
@@ -390,6 +400,7 @@ func TestAccGroup_OnCallSchedule(t *testing.T) {
 
 func testAccGroupResourceWithAccessLevel(resourceID, accessLevelRemoteID string) string {
 	return fmt.Sprintf(`
+manage_resources = true
 resource {
 	id = "%s"
 	access_level_remote_id = "%s"


### PR DESCRIPTION
## Description of the change

Does 2 things:
1. Adds the group resource read function that I was previously left out by accident
2. Adds a boolean value to force users to explicitly opt into using group resources.

## Checklist

- [x] I performed a self-review of my code
- [x] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
