### PR TITLE
[OPAL-5496] Remove "default" part in max duration description

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -142,7 +142,7 @@ resource "opal_group" "google_group_example" {
 - `description` (String) The description of the group.
 - `is_requestable` (Boolean) Allow users to create an access request for this group. By default, any group is requestable.
 - `manage_resources` (Boolean) Boolean flag to indicate if you intend to manage group <-> resource relationships via terraform.
-- `max_duration` (Number) The maximum duration for which this group can be requested (in minutes). By default, the max duration is indefinite access.
+- `max_duration` (Number) The maximum duration for which this group can be requested (in minutes).
 - `on_call_schedule` (Block Set) An on call schedule for this group. (see [below for nested schema](#nestedblock--on_call_schedule))
 - `recommended_duration` (Number) The recommended duration for which the group should be requested (in minutes). Will be the default value in a request. Use -1 to set to indefinite.
 - `remote_info` (Block List, Max: 1) Remote info that is required for the creation of remote groups. (see [below for nested schema](#nestedblock--remote_info))

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -151,7 +151,7 @@ resource "opal_resource" "github_repo_example" {
 - `auto_approval` (Boolean) Automatically approve all requests for this resource without review.
 - `description` (String) The description of the resource.
 - `is_requestable` (Boolean) Allow users to create an access request for this resource. By default, any resource is requestable.
-- `max_duration` (Number) The maximum duration for which this resource can be requested (in minutes). By default, the max duration is indefinite access.
+- `max_duration` (Number) The maximum duration for which this resource can be requested (in minutes).
 - `recommended_duration` (Number) The recommended duration for which the resource should be requested (in minutes). Will be the default value in a request. Use -1 to set to indefinite.
 - `remote_info` (Block List, Max: 1) Remote info that is required for the creation of remote resources. (see [below for nested schema](#nestedblock--remote_info))
 - `request_template_id` (String) The ID of a request template for this resource. You can get this ID from the URL in the Opal web app.

--- a/opal/group.go
+++ b/opal/group.go
@@ -3,9 +3,10 @@ package opal
 import (
 	"context"
 	"fmt"
+	"reflect"
+
 	"github.com/opalsecurity/opal-go"
 	"github.com/pkg/errors"
-	"reflect"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -83,7 +84,7 @@ func resourceGroup() *schema.Resource {
 				Optional:    true,
 			},
 			"max_duration": {
-				Description: "The maximum duration for which this group can be requested (in minutes). By default, the max duration is indefinite access.",
+				Description: "The maximum duration for which this group can be requested (in minutes).",
 				Type:        schema.TypeInt,
 				Optional:    true,
 			},

--- a/opal/resource.go
+++ b/opal/resource.go
@@ -2,6 +2,7 @@ package opal
 
 import (
 	"context"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -94,7 +95,7 @@ func resourceResource() *schema.Resource {
 				Optional:    true,
 			},
 			"max_duration": {
-				Description: "The maximum duration for which this resource can be requested (in minutes). By default, the max duration is indefinite access.",
+				Description: "The maximum duration for which this resource can be requested (in minutes).",
 				Type:        schema.TypeInt,
 				Optional:    true,
 			},


### PR DESCRIPTION
## Description of the change
Remove "By default, the max duration is indefinite access" in max duration description. It was just confusing because unset and indefinite imply the same thing for max duration, but it was confusing when compared to recommended duration where unset and indefinite were separate settings, but we called the null value of max duration "indefinite" whereas we called the null value of recommended duration "unset". We should just call the null values of both unset.

## Checklist

- [ ] I performed a self-review of my code
- [ ] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
