### PR TITLE
Add support for AWS Identity Center

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Terraform Opal Provider
-[![Terraform Provider Tests](https://github.com/opalsecurity/terraform-provider-opal/actions/workflows/test.yml/badge.svg)](https://github.com/opalsecurity/terraform-provider-opal/actions/workflows/test.yml)
 
-This project is under **active development** and is not yet ready for use.
+[![Terraform Provider Tests](https://github.com/opalsecurity/terraform-provider-opal/actions/workflows/test.yml/badge.svg)](https://github.com/opalsecurity/terraform-provider-opal/actions/workflows/test.yml)
 
 ## Installation
 
@@ -23,7 +22,8 @@ provider "opal" {
 
 ## Development
 
-Go `>= 1.18` and terraform `>= 0.14` is required for development. It's recommended that you use a [`dev_overrides` block](https://www.terraform.io/cli/config/config-file) while developing:
+Go `>= 1.20` and terraform `>= 0.14` is required for development. It's recommended that you use a [`dev_overrides` block](https://www.terraform.io/cli/config/config-file) while developing:
+
 ```hcl
 provider_installation {
   dev_overrides {
@@ -38,17 +38,20 @@ provider_installation {
 ```
 
 You can also source your local `OPAL_AUTH_TOKEN` while developing by using [direnv](https://direnv.net) (installable via homebrew) and creating a `.envrc.local` file:
+
 ```bash
 # Get an auth token from https://app.opal.dev/settings#api or your Opal installation.
 export OPAL_AUTH_TOKEN=YOUR_TOKEN_HERE
 ```
 
 You can build the plugin using:
+
 ```
 make build
 ```
 
 Your `dev_overrides` configured above should tell your local terraform installation how to resolve the plugin:
+
 ```
 $ cd examples/
 $ terraform apply

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -111,6 +111,19 @@ resource "opal_resource" "aws_iam_role_example" {
   }
 }
 
+resource "opal_resource" "aws_permission_set" {
+  name                 = "AWS permission set"
+  // ...
+
+  remote_info {
+    aws_permission_set {
+      # Note: This can reference your AWS terraform files
+      account_id = "234234234234"
+      arn        = "arn:aws:sso:::permissionSet/ssoins-123123123abcdefg/ps-abc123abc123abcd"
+    }
+  }
+}
+
 resource "opal_resource" "okta_app_example" {
   name = "Okta app"
   // ...
@@ -175,6 +188,7 @@ Optional:
 - `aws_ec2_instance` (Block List, Max: 1) The remote_info for an AWS EC2 instance. (see [below for nested schema](#nestedblock--remote_info--aws_ec2_instance))
 - `aws_eks_cluster` (Block List, Max: 1) The remote_info for an AWS EKS cluster. (see [below for nested schema](#nestedblock--remote_info--aws_eks_cluster))
 - `aws_iam_role` (Block List, Max: 1) The remote_info for an AWS IAM role. (see [below for nested schema](#nestedblock--remote_info--aws_iam_role))
+- `aws_permission_set` (Block List, Max: 1) The remote_info for an AWS permission set. (see [below for nested schema](#nestedblock--remote_info--aws_permission_set))
 - `aws_rds_instance` (Block List, Max: 1) The remote_info for an AWS RDS instance. (see [below for nested schema](#nestedblock--remote_info--aws_rds_instance))
 - `github_repo` (Block List, Max: 1) The remote_info for a Github repo. (see [below for nested schema](#nestedblock--remote_info--github_repo))
 - `gitlab_project` (Block List, Max: 1) The remote_info for a Gitlab project. (see [below for nested schema](#nestedblock--remote_info--gitlab_project))
@@ -206,6 +220,15 @@ Required:
 Required:
 
 - `arn` (String) The ARN of the IAM role.
+
+
+<a id="nestedblock--remote_info--aws_permission_set"></a>
+### Nested Schema for `remote_info.aws_permission_set`
+
+Required:
+
+- `account_id` (String) The ID of the AWS account.
+- `arn` (String) The ARN of the permission set.
 
 
 <a id="nestedblock--remote_info--aws_rds_instance"></a>

--- a/examples/resources/remote_resource.tf
+++ b/examples/resources/remote_resource.tf
@@ -13,6 +13,19 @@ resource "opal_resource" "aws_iam_role_example" {
   }
 }
 
+resource "opal_resource" "aws_permission_set" {
+  name                 = "AWS permission set"
+  // ...
+
+  remote_info {
+    aws_permission_set {
+      # Note: This can reference your AWS terraform files
+      account_id = "234234234234"
+      arn        = "arn:aws:sso:::permissionSet/ssoins-123123123abcdefg/ps-abc123abc123abcd"
+    }
+  }
+}
+
 resource "opal_resource" "okta_app_example" {
   name = "Okta app"
   // ...

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
-	github.com/opalsecurity/opal-go v1.0.21
+	github.com/opalsecurity/opal-go v1.0.23
 	github.com/pkg/errors v0.9.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/opalsecurity/opal-go v1.0.21 h1:tKOfn+QrzBZvZy7ZiOmnulil1sF73LWDbHiZ3fDWvQc=
-github.com/opalsecurity/opal-go v1.0.21/go.mod h1:cdQrqgbdjsZHjrKV8ibsle6r6c7jRBKryI1x3oSVm1I=
+github.com/opalsecurity/opal-go v1.0.23 h1:TUZ9XoHlVBTNfhgytPOA9QEWhHoYMrKZcRRnVE9rF3c=
+github.com/opalsecurity/opal-go v1.0.23/go.mod h1:cdQrqgbdjsZHjrKV8ibsle6r6c7jRBKryI1x3oSVm1I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opal/resource_remote_info.go
+++ b/opal/resource_remote_info.go
@@ -2,6 +2,7 @@ package opal
 
 import (
 	"errors"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/opalsecurity/opal-go"
 )
@@ -89,6 +90,28 @@ func resourceRemoteInfoElem() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"arn": {
 							Description: "The ARN of the EKS cluster.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+			"aws_permission_set": {
+				Description: "The remote_info for an AWS permission set.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"arn": {
+							Description: "The ARN of the permission set.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+						"account_id": {
+							Description: "The ID of the AWS account.",
 							Type:        schema.TypeString,
 							Required:    true,
 							ForceNew:    true,
@@ -251,6 +274,18 @@ func parseResourceRemoteInfo(remoteInfoI interface{}) (*opal.ResourceRemoteInfo,
 			return &opal.ResourceRemoteInfo{
 				AwsEksCluster: &opal.ResourceRemoteInfoAwsEksCluster{
 					Arn: awsEksCluster["arn"].(string),
+				},
+			}, nil
+		}
+	}
+	if awsPermissionSetI, ok := remoteInfoMap["aws_permission_set"]; ok {
+		awsPermissionSetIList := awsPermissionSetI.([]interface{})
+		if len(awsPermissionSetIList) == 1 {
+			awsPermissionSet := awsPermissionSetIList[0].(map[string]any)
+			return &opal.ResourceRemoteInfo{
+				AwsPermissionSet: &opal.ResourceRemoteInfoAwsPermissionSet{
+					Arn:       awsPermissionSet["arn"].(string),
+					AccountId: awsPermissionSet["account_id"].(string),
 				},
 			}, nil
 		}


### PR DESCRIPTION
## Description of the change

- Support creating and deleting permission sets
- Remote info will be imported for permission sets so that the parent accounts can be referenced and modified as desired

- [x] Note: Build will fail until new version of the Go SDK is released.

## Checklist

- [x] I performed a self-review of my code
- [x] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
