### PR TITLE
Require Go 1.20, 1.18 is EOL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opalsecurity/terraform-provider-opal
 
-go 1.18
+go 1.20
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1


### PR DESCRIPTION
## Description of the change

Go 1.18 is EOL since Jan 2023. This PR would require Go 1.20.

Go versions < 1.20 use a custom DNS resolver rather than the system resolver, causing issues when trying to use the Opal Terraform provider using against an Opal URL with private DNS resolvable through a VPN client. This PR would require Go 1.20. I've tested this locally and it resolves the DNS resolution issue for us.

## Checklist

- [X] I performed a self-review of my code
- [X] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
