### PR TITLE
[OPAL-7906] Support AWS accounts in Terraform

### DIFF
--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -185,6 +185,7 @@ resource "opal_resource" "github_repo_example" {
 
 Optional:
 
+- `aws_account` (Block List, Max: 1) The remote_info for an AWS account. (see [below for nested schema](#nestedblock--remote_info--aws_account))
 - `aws_ec2_instance` (Block List, Max: 1) The remote_info for an AWS EC2 instance. (see [below for nested schema](#nestedblock--remote_info--aws_ec2_instance))
 - `aws_eks_cluster` (Block List, Max: 1) The remote_info for an AWS EKS cluster. (see [below for nested schema](#nestedblock--remote_info--aws_eks_cluster))
 - `aws_iam_role` (Block List, Max: 1) The remote_info for an AWS IAM role. (see [below for nested schema](#nestedblock--remote_info--aws_iam_role))
@@ -197,6 +198,14 @@ Optional:
 - `okta_standard_role` (Block List, Max: 1) The remote_info for an Okta standard role. (see [below for nested schema](#nestedblock--remote_info--okta_standard_role))
 - `teleport_role` (Block List, Max: 1) The remote_info for a Teleport role. (see [below for nested schema](#nestedblock--remote_info--teleport_role))
 
+<a id="nestedblock--remote_info--aws_account"></a>
+### Nested Schema for `remote_info.aws_account`
+
+Required:
+
+- `account_id` (String) The ID of the AWS account.
+
+
 <a id="nestedblock--remote_info--aws_ec2_instance"></a>
 ### Nested Schema for `remote_info.aws_ec2_instance`
 
@@ -204,6 +213,10 @@ Required:
 
 - `instance_id` (String) The instanceId of the EC2 instance.
 - `region` (String) The region of the EC2 instance.
+
+Optional:
+
+- `account_id` (String) The ID of the AWS account.
 
 
 <a id="nestedblock--remote_info--aws_eks_cluster"></a>
@@ -213,6 +226,10 @@ Required:
 
 - `arn` (String) The ARN of the EKS cluster.
 
+Optional:
+
+- `account_id` (String) The ID of the AWS account.
+
 
 <a id="nestedblock--remote_info--aws_iam_role"></a>
 ### Nested Schema for `remote_info.aws_iam_role`
@@ -220,6 +237,10 @@ Required:
 Required:
 
 - `arn` (String) The ARN of the IAM role.
+
+Optional:
+
+- `account_id` (String) The ID of the AWS account.
 
 
 <a id="nestedblock--remote_info--aws_permission_set"></a>
@@ -239,6 +260,10 @@ Required:
 - `instance_id` (String) The instanceId of the RDS instance.
 - `region` (String) The region of the RDS instance.
 - `resource_id` (String) The resourceId of the RDS instance.
+
+Optional:
+
+- `account_id` (String) The ID of the AWS account.
 
 
 <a id="nestedblock--remote_info--github_repo"></a>

--- a/opal/verify.go
+++ b/opal/verify.go
@@ -2,6 +2,7 @@ package opal
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/opalsecurity/opal-go"
 	"github.com/pkg/errors"
 )
 
@@ -9,7 +10,8 @@ import (
 // - a reviewer_stage is defined
 // - auto_approve is set to true
 // - is_requestable is set to false
-// NOTE: We only care that one of these 3 is correct in order for the item to have a valid reviewer config
+// - resource_type is set to a parent resource type (e.g. AWS_ACCOUNT)
+// NOTE: We only care that one of these 4 is correct in order for the item to have a valid reviewer config
 // without needing to fall back on the default creation behavior which would cause an immediate diff after
 // creation
 func validateReviewerConfigDuringCreate(d *schema.ResourceData) error {
@@ -25,6 +27,11 @@ func validateReviewerConfigDuringCreate(d *schema.ResourceData) error {
 	}
 	if isRequestableI, ok := d.GetOkExists("is_requestable"); ok {
 		if !isRequestableI.(bool) {
+			return nil
+		}
+	}
+	if resourceTypeI, ok := d.GetOkExists("resource_type"); ok {
+		if opal.ResourceTypeEnum(resourceTypeI.(string)) == opal.RESOURCETYPEENUM_AWS_ACCOUNT {
 			return nil
 		}
 	}


### PR DESCRIPTION
## Description of the change
We were out of parity with the SDK, this supports it.

Test AWS accounts:
![Screenshot 2023-08-10 at 11 15 34 AM](https://github.com/opalsecurity/terraform-provider-opal/assets/131023844/4d25a849-33cf-434e-8062-87845d27bee0)

Test AWS role:
![Screenshot 2023-08-10 at 11 31 57 AM](https://github.com/opalsecurity/terraform-provider-opal/assets/131023844/354c9af5-8413-43cb-a9ce-2f72ccd23dcd)


## Checklist

- [x] I performed a self-review of my code
- [x] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
