### PR TITLE
Add resource creation support for GCP, Salesforce, and Pagerduty

### DIFF
--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -191,11 +191,21 @@ Optional:
 - `aws_iam_role` (Block List, Max: 1) The remote_info for an AWS IAM role. (see [below for nested schema](#nestedblock--remote_info--aws_iam_role))
 - `aws_permission_set` (Block List, Max: 1) The remote_info for an AWS permission set. (see [below for nested schema](#nestedblock--remote_info--aws_permission_set))
 - `aws_rds_instance` (Block List, Max: 1) The remote_info for an AWS RDS instance. (see [below for nested schema](#nestedblock--remote_info--aws_rds_instance))
+- `gcp_bucket` (Block List, Max: 1) The remote_info for a GCP bucket. (see [below for nested schema](#nestedblock--remote_info--gcp_bucket))
+- `gcp_compute_instance` (Block List, Max: 1) The remote_info for a GCP compute instance. (see [below for nested schema](#nestedblock--remote_info--gcp_compute_instance))
+- `gcp_folder` (Block List, Max: 1) The remote_info for a GCP folder. (see [below for nested schema](#nestedblock--remote_info--gcp_folder))
+- `gcp_gke_cluster` (Block List, Max: 1) The remote_info for a GCP GKE cluster. (see [below for nested schema](#nestedblock--remote_info--gcp_gke_cluster))
+- `gcp_project` (Block List, Max: 1) The remote_info for a GCP project. (see [below for nested schema](#nestedblock--remote_info--gcp_project))
+- `gcp_sql_instance` (Block List, Max: 1) The remote_info for a GCP SQL instance. (see [below for nested schema](#nestedblock--remote_info--gcp_sql_instance))
 - `github_repo` (Block List, Max: 1) The remote_info for a Github repo. (see [below for nested schema](#nestedblock--remote_info--github_repo))
 - `gitlab_project` (Block List, Max: 1) The remote_info for a Gitlab project. (see [below for nested schema](#nestedblock--remote_info--gitlab_project))
 - `okta_app` (Block List, Max: 1) The remote_info for an Okta app. (see [below for nested schema](#nestedblock--remote_info--okta_app))
 - `okta_custom_role` (Block List, Max: 1) The remote_info for an Okta custom role. (see [below for nested schema](#nestedblock--remote_info--okta_custom_role))
 - `okta_standard_role` (Block List, Max: 1) The remote_info for an Okta standard role. (see [below for nested schema](#nestedblock--remote_info--okta_standard_role))
+- `pagerduty_role` (Block List, Max: 1) The remote_info for a Pagerduty role. (see [below for nested schema](#nestedblock--remote_info--pagerduty_role))
+- `salesforce_permission_set` (Block List, Max: 1) The remote_info for a Salesforce permission set. (see [below for nested schema](#nestedblock--remote_info--salesforce_permission_set))
+- `salesforce_profile` (Block List, Max: 1) The remote_info for a Salesforce profile. (see [below for nested schema](#nestedblock--remote_info--salesforce_profile))
+- `salesforce_role` (Block List, Max: 1) The remote_info for a Salesforce role. (see [below for nested schema](#nestedblock--remote_info--salesforce_role))
 - `teleport_role` (Block List, Max: 1) The remote_info for a Teleport role. (see [below for nested schema](#nestedblock--remote_info--teleport_role))
 
 <a id="nestedblock--remote_info--aws_account"></a>
@@ -266,6 +276,57 @@ Optional:
 - `account_id` (String) The ID of the AWS account.
 
 
+<a id="nestedblock--remote_info--gcp_bucket"></a>
+### Nested Schema for `remote_info.gcp_bucket`
+
+Required:
+
+- `bucket_id` (String) The id of the bucket.
+
+
+<a id="nestedblock--remote_info--gcp_compute_instance"></a>
+### Nested Schema for `remote_info.gcp_compute_instance`
+
+Required:
+
+- `instance_id` (String) The id of the compute instance.
+- `project_id` (String) The id of the project the instance is in.
+- `zone` (String) The zone of the compute instance.
+
+
+<a id="nestedblock--remote_info--gcp_folder"></a>
+### Nested Schema for `remote_info.gcp_folder`
+
+Required:
+
+- `folder_id` (String) The id of the folder.
+
+
+<a id="nestedblock--remote_info--gcp_gke_cluster"></a>
+### Nested Schema for `remote_info.gcp_gke_cluster`
+
+Required:
+
+- `cluster_name` (String) The name of the cluster.
+
+
+<a id="nestedblock--remote_info--gcp_project"></a>
+### Nested Schema for `remote_info.gcp_project`
+
+Required:
+
+- `project_id` (String) The id of the project.
+
+
+<a id="nestedblock--remote_info--gcp_sql_instance"></a>
+### Nested Schema for `remote_info.gcp_sql_instance`
+
+Required:
+
+- `instance_id` (String) The id of the sql instance.
+- `project_id` (String) The id of the project the instance is in.
+
+
 <a id="nestedblock--remote_info--github_repo"></a>
 ### Nested Schema for `remote_info.github_repo`
 
@@ -304,6 +365,39 @@ Required:
 Required:
 
 - `role_type` (String) The type of the role.
+
+
+<a id="nestedblock--remote_info--pagerduty_role"></a>
+### Nested Schema for `remote_info.pagerduty_role`
+
+Required:
+
+- `role_name` (String) The name of the role.
+
+
+<a id="nestedblock--remote_info--salesforce_permission_set"></a>
+### Nested Schema for `remote_info.salesforce_permission_set`
+
+Required:
+
+- `permission_set_id` (String) The id of the permission set.
+
+
+<a id="nestedblock--remote_info--salesforce_profile"></a>
+### Nested Schema for `remote_info.salesforce_profile`
+
+Required:
+
+- `profile_id` (String) The id of the profile.
+- `user_license_id` (String) The id of the user license.
+
+
+<a id="nestedblock--remote_info--salesforce_role"></a>
+### Nested Schema for `remote_info.salesforce_role`
+
+Required:
+
+- `role_id` (String) The id of the role.
 
 
 <a id="nestedblock--remote_info--teleport_role"></a>

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
-	github.com/opalsecurity/opal-go v1.0.24
+	github.com/opalsecurity/opal-go v1.0.25
 	github.com/pkg/errors v0.9.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/opalsecurity/opal-go v1.0.23 h1:TUZ9XoHlVBTNfhgytPOA9QEWhHoYMrKZcRRnV
 github.com/opalsecurity/opal-go v1.0.23/go.mod h1:cdQrqgbdjsZHjrKV8ibsle6r6c7jRBKryI1x3oSVm1I=
 github.com/opalsecurity/opal-go v1.0.24 h1:8CSsqC7V1m2oyGNVfmaH7GOyBPBoQ08+TVtydfxXrbM=
 github.com/opalsecurity/opal-go v1.0.24/go.mod h1:cdQrqgbdjsZHjrKV8ibsle6r6c7jRBKryI1x3oSVm1I=
+github.com/opalsecurity/opal-go v1.0.25 h1:XPlvDvcYIlSU0fpC7mn3MD56IEv4B+0X2eF0eAgO5pc=
+github.com/opalsecurity/opal-go v1.0.25/go.mod h1:cdQrqgbdjsZHjrKV8ibsle6r6c7jRBKryI1x3oSVm1I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opal/group.go
+++ b/opal/group.go
@@ -453,7 +453,7 @@ func resourceGroupUpdateResources(ctx context.Context, d *schema.ResourceData, c
 func resourceGroupUpdateReviewerStages(ctx context.Context, d *schema.ResourceData, client *opal.APIClient, reviewerStagesI any) diag.Diagnostics {
 	rawReviewerStages := reviewerStagesI.([]any)
 	reviewerStages := make([]opal.ReviewerStage, 0, len(rawReviewerStages))
-	for _, rawReviewerStage := range rawReviewerStages {
+	for i, rawReviewerStage := range rawReviewerStages {
 		reviewerStage := rawReviewerStage.(map[string]any)
 		requireManagerApproval := reviewerStage["require_manager_approval"].(bool)
 		operator := reviewerStage["operator"].(string)
@@ -463,7 +463,7 @@ func resourceGroupUpdateReviewerStages(ctx context.Context, d *schema.ResourceDa
 			return diagFromErr(ctx, err)
 		}
 
-		reviewerStages = append(reviewerStages, *opal.NewReviewerStage(requireManagerApproval, operator, reviewerIds))
+		reviewerStages = append(reviewerStages, *opal.NewReviewerStage(requireManagerApproval, operator, reviewerIds, int32(i+1)))
 		tflog.Debug(ctx, "Setting group reviewer stage", map[string]any{
 			"id":                     d.Id(),
 			"requireManagerApproval": requireManagerApproval,

--- a/opal/resource.go
+++ b/opal/resource.go
@@ -323,7 +323,7 @@ func resourceResourceUpdateVisibility(ctx context.Context, d *schema.ResourceDat
 func resourceResourceUpdateReviewerStages(ctx context.Context, d *schema.ResourceData, client *opal.APIClient, reviewerStagesI any) diag.Diagnostics {
 	rawReviewerStages := reviewerStagesI.([]any)
 	reviewerStages := make([]opal.ReviewerStage, 0, len(rawReviewerStages))
-	for _, rawReviewerStage := range rawReviewerStages {
+	for i, rawReviewerStage := range rawReviewerStages {
 		reviewerStage := rawReviewerStage.(map[string]any)
 		requireManagerApproval := reviewerStage["require_manager_approval"].(bool)
 		operator := reviewerStage["operator"].(string)
@@ -333,7 +333,7 @@ func resourceResourceUpdateReviewerStages(ctx context.Context, d *schema.Resourc
 			return diagFromErr(ctx, err)
 		}
 
-		reviewerStages = append(reviewerStages, *opal.NewReviewerStage(requireManagerApproval, operator, reviewerIds))
+		reviewerStages = append(reviewerStages, *opal.NewReviewerStage(requireManagerApproval, operator, reviewerIds, int32(i+1)))
 		tflog.Debug(ctx, "Setting resource reviewer stage", map[string]any{
 			"id":                     d.Id(),
 			"requireManagerApproval": requireManagerApproval,

--- a/opal/resource_remote_info.go
+++ b/opal/resource_remote_info.go
@@ -159,6 +159,120 @@ func resourceRemoteInfoElem() *schema.Resource {
 					},
 				},
 			},
+			"gcp_bucket": {
+				Description: "The remote_info for a GCP bucket.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bucket_id": {
+							Description: "The id of the bucket.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+			"gcp_compute_instance": {
+				Description: "The remote_info for a GCP compute instance.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_id": {
+							Description: "The id of the compute instance.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+						"project_id": {
+							Description: "The id of the project the instance is in.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+						"zone": {
+							Description: "The zone of the compute instance.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+			"gcp_folder": {
+				Description: "The remote_info for a GCP folder.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"folder_id": {
+							Description: "The id of the folder.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+			"gcp_gke_cluster": {
+				Description: "The remote_info for a GCP GKE cluster.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cluster_name": {
+							Description: "The name of the cluster.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+			"gcp_project": {
+				Description: "The remote_info for a GCP project.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"project_id": {
+							Description: "The id of the project.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+			"gcp_sql_instance": {
+				Description: "The remote_info for a GCP SQL instance.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_id": {
+							Description: "The id of the sql instance.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+						"project_id": {
+							Description: "The id of the project the instance is in.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
 			"github_repo": {
 				Description: "The remote_info for a Github repo.",
 				Type:        schema.TypeList,
@@ -225,6 +339,76 @@ func resourceRemoteInfoElem() *schema.Resource {
 			},
 			"okta_custom_role": {
 				Description: "The remote_info for an Okta custom role.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"role_id": {
+							Description: "The id of the role.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+			"pagerduty_role": {
+				Description: "The remote_info for a Pagerduty role.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"role_name": {
+							Description: "The name of the role.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+			"salesforce_permission_set": {
+				Description: "The remote_info for a Salesforce permission set.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"permission_set_id": {
+							Description: "The id of the permission set.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+			"salesforce_profile": {
+				Description: "The remote_info for a Salesforce profile.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"profile_id": {
+							Description: "The id of the profile.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+						"user_license_id": {
+							Description: "The id of the user license.",
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+			"salesforce_role": {
+				Description: "The remote_info for a Salesforce role.",
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Optional:    true,
@@ -361,6 +545,81 @@ func parseResourceRemoteInfo(remoteInfoI interface{}) (*opal.ResourceRemoteInfo,
 			}, nil
 		}
 	}
+	if gcpBucketI, ok := remoteInfoMap["gcp_bucket"]; ok {
+		gcpBucketIList := gcpBucketI.([]interface{})
+
+		if len(gcpBucketIList) == 1 {
+			gcpBucket := gcpBucketIList[0].(map[string]any)
+			return &opal.ResourceRemoteInfo{
+				GcpBucket: &opal.ResourceRemoteInfoGcpBucket{
+					BucketId: gcpBucket["bucket_id"].(string),
+				},
+			}, nil
+		}
+	}
+	if gcpComputeInstanceI, ok := remoteInfoMap["gcp_compute_instance"]; ok {
+		gcpComputeInstanceIList := gcpComputeInstanceI.([]interface{})
+
+		if len(gcpComputeInstanceIList) == 1 {
+			gcpComputeInstance := gcpComputeInstanceIList[0].(map[string]any)
+			return &opal.ResourceRemoteInfo{
+				GcpComputeInstance: &opal.ResourceRemoteInfoGcpComputeInstance{
+					InstanceId: gcpComputeInstance["instance_id"].(string),
+					ProjectId:  gcpComputeInstance["project_id"].(string),
+					Zone:       gcpComputeInstance["zone"].(string),
+				},
+			}, nil
+		}
+	}
+	if gcpFolderI, ok := remoteInfoMap["gcp_folder"]; ok {
+		gcpFolderIList := gcpFolderI.([]interface{})
+
+		if len(gcpFolderIList) == 1 {
+			gcpFolder := gcpFolderIList[0].(map[string]any)
+			return &opal.ResourceRemoteInfo{
+				GcpFolder: &opal.ResourceRemoteInfoGcpFolder{
+					FolderId: gcpFolder["folder_id"].(string),
+				},
+			}, nil
+		}
+	}
+	if gcpGkeClusterI, ok := remoteInfoMap["gcp_gke_cluster"]; ok {
+		gcpGkeClusterIList := gcpGkeClusterI.([]interface{})
+
+		if len(gcpGkeClusterIList) == 1 {
+			gcpGkeCluster := gcpGkeClusterIList[0].(map[string]any)
+			return &opal.ResourceRemoteInfo{
+				GcpGkeCluster: &opal.ResourceRemoteInfoGcpGkeCluster{
+					ClusterName: gcpGkeCluster["cluster_name"].(string),
+				},
+			}, nil
+		}
+	}
+	if gcpProjectI, ok := remoteInfoMap["gcp_project"]; ok {
+		gcpProjectIList := gcpProjectI.([]interface{})
+
+		if len(gcpProjectIList) == 1 {
+			gcpProject := gcpProjectIList[0].(map[string]any)
+			return &opal.ResourceRemoteInfo{
+				GcpProject: &opal.ResourceRemoteInfoGcpProject{
+					ProjectId: gcpProject["project_id"].(string),
+				},
+			}, nil
+		}
+	}
+	if gcpSqlInstanceI, ok := remoteInfoMap["gcp_sql_instance"]; ok {
+		gcpSqlInstanceIList := gcpSqlInstanceI.([]interface{})
+
+		if len(gcpSqlInstanceIList) == 1 {
+			gcpSqlInstance := gcpSqlInstanceIList[0].(map[string]any)
+			return &opal.ResourceRemoteInfo{
+				GcpSqlInstance: &opal.ResourceRemoteInfoGcpSqlInstance{
+					InstanceId: gcpSqlInstance["instance_id"].(string),
+					ProjectId:  gcpSqlInstance["project_id"].(string),
+				},
+			}, nil
+		}
+	}
 	if githubRepoI, ok := remoteInfoMap["github_repo"]; ok {
 		githubRepoIList := githubRepoI.([]interface{})
 
@@ -417,6 +676,55 @@ func parseResourceRemoteInfo(remoteInfoI interface{}) (*opal.ResourceRemoteInfo,
 			return &opal.ResourceRemoteInfo{
 				OktaCustomRole: &opal.ResourceRemoteInfoOktaCustomRole{
 					RoleId: oktaCustomRole["role_id"].(string),
+				},
+			}, nil
+		}
+	}
+	if pagerdutyRoleI, ok := remoteInfoMap["pagerduty_role"]; ok {
+		pagerdutyRoleIList := pagerdutyRoleI.([]interface{})
+
+		if len(pagerdutyRoleIList) == 1 {
+			pagerdutyRole := pagerdutyRoleIList[0].(map[string]any)
+			return &opal.ResourceRemoteInfo{
+				PagerdutyRole: &opal.ResourceRemoteInfoPagerdutyRole{
+					RoleName: pagerdutyRole["role_name"].(string),
+				},
+			}, nil
+		}
+	}
+	if salesforcePermissionSetI, ok := remoteInfoMap["salesforce_permission_set"]; ok {
+		salesforcePermissionSetIList := salesforcePermissionSetI.([]interface{})
+
+		if len(salesforcePermissionSetIList) == 1 {
+			salesforcePermissionSet := salesforcePermissionSetIList[0].(map[string]any)
+			return &opal.ResourceRemoteInfo{
+				SalesforcePermissionSet: &opal.ResourceRemoteInfoSalesforcePermissionSet{
+					PermissionSetId: salesforcePermissionSet["permission_set_id"].(string),
+				},
+			}, nil
+		}
+	}
+	if salesforceProfileI, ok := remoteInfoMap["salesforce_profile"]; ok {
+		salesforceProfileIList := salesforceProfileI.([]interface{})
+
+		if len(salesforceProfileIList) == 1 {
+			salesforceProfile := salesforceProfileIList[0].(map[string]any)
+			return &opal.ResourceRemoteInfo{
+				SalesforceProfile: &opal.ResourceRemoteInfoSalesforceProfile{
+					ProfileId:     salesforceProfile["profile_id"].(string),
+					UserLicenseId: salesforceProfile["user_license_id"].(string),
+				},
+			}, nil
+		}
+	}
+	if salesforceRoleI, ok := remoteInfoMap["salesforce_role"]; ok {
+		salesforceRoleIList := salesforceRoleI.([]interface{})
+
+		if len(salesforceRoleIList) == 1 {
+			salesforceRole := salesforceRoleIList[0].(map[string]any)
+			return &opal.ResourceRemoteInfo{
+				SalesforceRole: &opal.ResourceRemoteInfoSalesforceRole{
+					RoleId: salesforceRole["role_id"].(string),
 				},
 			}, nil
 		}


### PR DESCRIPTION
## Description of the change

- updates to latest opal-go
- updates the callsite for creating reviewer stages to pass in an explicit reviewer stage. Does not make any changes to how the user provides the stage (it is still implicit by ordering of the stages rather than explicitly passing in a number)
- adds the ability to create resources for GCP, Pagerduty, and Salesforce

## Testing
- tested for each new resource type that I can create the resource from terraform + sync for the resource succeed

## Checklist

- [x] I performed a self-review of my code
- [x] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
