### PR TITLE
Read remote info into terraform

### DIFF
--- a/opal/group.go
+++ b/opal/group.go
@@ -300,7 +300,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, m any) dia
 		createInfo.SetDescription(descI.(string))
 	}
 	if remoteInfoI, ok := d.GetOk("remote_info"); ok {
-		remoteInfo, err := parseGroupRemoteInfo(remoteInfoI)
+		remoteInfo, err := groupRemoteInfoTerraformToAPI(remoteInfoI)
 		if err != nil {
 			return diagFromErr(ctx, err)
 		}
@@ -578,6 +578,14 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 		d.Set("is_requestable", group.IsRequestable),
 	); err.ErrorOrNil() != nil {
 		return diagFromErr(ctx, err)
+	}
+
+	remoteInfoI, err := groupRemoteInfoAPIToTerraform(group.RemoteInfo)
+	if err != nil {
+		return diagFromErr(ctx, err)
+	}
+	if remoteInfoI != nil {
+		d.Set("remote_info", remoteInfoI)
 	}
 
 	visibility, _, err := client.GroupsApi.GetGroupVisibility(ctx, group.GroupId).Execute()

--- a/opal/group_remote_info.go
+++ b/opal/group_remote_info.go
@@ -163,8 +163,12 @@ func groupRemoteInfoElem() *schema.Resource {
 	}
 }
 
-// NOTE: See comment in `resourceRemoteInfoElem` for why the parsing is so convoluted.
-func parseGroupRemoteInfo(remoteInfoI interface{}) (*opal.GroupRemoteInfo, error) {
+func groupRemoteInfoAPIToTerraform(remoteInfo *opal.GroupRemoteInfo) (interface{}, error) {
+	return remoteInfoAPIToTerraformInternal(remoteInfo)
+}
+
+// NOTE: See comment in `groupRemoteInfoElem` for why the parsing is so convoluted.
+func groupRemoteInfoTerraformToAPI(remoteInfoI interface{}) (*opal.GroupRemoteInfo, error) {
 	remoteInfoIList := remoteInfoI.([]interface{})
 	if len(remoteInfoIList) != 1 {
 		return nil, errors.New("you cannot provide multiple remote_info blobs")

--- a/opal/resource.go
+++ b/opal/resource.go
@@ -161,6 +161,7 @@ func resourceResource() *schema.Resource {
 				Description: "Remote info that is required for the creation of remote resources.",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				MaxItems:    1,
 				Elem:        resourceRemoteInfoElem(),

--- a/opal/resource.go
+++ b/opal/resource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -251,7 +250,7 @@ func resourceResourceCreate(ctx context.Context, d *schema.ResourceData, m any) 
 	}
 
 	if remoteInfoI, ok := d.GetOk("remote_info"); ok {
-		remoteInfo, err := parseResourceRemoteInfo(remoteInfoI)
+		remoteInfo, err := resourceRemoteInfoTerraformToAPI(remoteInfoI)
 		if err != nil {
 			return diagFromErr(ctx, err)
 		}
@@ -422,6 +421,14 @@ func resourceResourceRead(ctx context.Context, d *schema.ResourceData, m any) di
 		d.Set("is_requestable", resource.IsRequestable),
 	); err.ErrorOrNil() != nil {
 		return diagFromErr(ctx, err)
+	}
+
+	remoteInfoI, err := resourceRemoteInfoAPIToTerraform(resource.RemoteInfo)
+	if err != nil {
+		return diagFromErr(ctx, err)
+	}
+	if remoteInfoI != nil {
+		d.Set("remote_info", remoteInfoI)
 	}
 
 	visibility, _, err := client.ResourcesApi.GetResourceVisibility(ctx, resource.ResourceId).Execute()


### PR DESCRIPTION
## Description of the change

This allows for the `remote_info` blob to be read into terraform during `terraform import`. 

## Testing

Tested the following cases:
- `terraform import` imports the remote_info state as expected
- terraform state that previously was imported when `remote_info` was not imported into the state file does not cause unexpected diffs after this change

## Checklist

- [x] I performed a self-review of my code
- [x] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
