### PR TITLE
Allow using owners with `/` in their name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
-	github.com/opalsecurity/opal-go v1.0.25
+	github.com/opalsecurity/opal-go v1.0.28
 	github.com/pkg/errors v0.9.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/opalsecurity/opal-go v1.0.24 h1:8CSsqC7V1m2oyGNVfmaH7GOyBPBoQ08+TVtyd
 github.com/opalsecurity/opal-go v1.0.24/go.mod h1:cdQrqgbdjsZHjrKV8ibsle6r6c7jRBKryI1x3oSVm1I=
 github.com/opalsecurity/opal-go v1.0.25 h1:XPlvDvcYIlSU0fpC7mn3MD56IEv4B+0X2eF0eAgO5pc=
 github.com/opalsecurity/opal-go v1.0.25/go.mod h1:cdQrqgbdjsZHjrKV8ibsle6r6c7jRBKryI1x3oSVm1I=
+github.com/opalsecurity/opal-go v1.0.28 h1:/kNp0Jp4bF8GXxLdFMWIwgGAXWRfiEXTHc1mg20gVUY=
+github.com/opalsecurity/opal-go v1.0.28/go.mod h1:cdQrqgbdjsZHjrKV8ibsle6r6c7jRBKryI1x3oSVm1I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/opal/group.go
+++ b/opal/group.go
@@ -505,7 +505,7 @@ func resourceGroupUpdateResources(ctx context.Context, d *schema.ResourceData, c
 func resourceGroupUpdateReviewerStages(ctx context.Context, d *schema.ResourceData, client *opal.APIClient, reviewerStagesI any) diag.Diagnostics {
 	rawReviewerStages := reviewerStagesI.([]any)
 	reviewerStages := make([]opal.ReviewerStage, 0, len(rawReviewerStages))
-	for i, rawReviewerStage := range rawReviewerStages {
+	for _, rawReviewerStage := range rawReviewerStages {
 		reviewerStage := rawReviewerStage.(map[string]any)
 		requireManagerApproval := reviewerStage["require_manager_approval"].(bool)
 		operator := reviewerStage["operator"].(string)
@@ -515,7 +515,7 @@ func resourceGroupUpdateReviewerStages(ctx context.Context, d *schema.ResourceDa
 			return diagFromErr(ctx, err)
 		}
 
-		reviewerStages = append(reviewerStages, *opal.NewReviewerStage(requireManagerApproval, operator, reviewerIds, int32(i+1)))
+		reviewerStages = append(reviewerStages, *opal.NewReviewerStage(requireManagerApproval, operator, reviewerIds))
 		tflog.Debug(ctx, "Setting group reviewer stage", map[string]any{
 			"id":                     d.Id(),
 			"requireManagerApproval": requireManagerApproval,

--- a/opal/resource.go
+++ b/opal/resource.go
@@ -371,7 +371,7 @@ func resourceResourceUpdateVisibility(ctx context.Context, d *schema.ResourceDat
 func resourceResourceUpdateReviewerStages(ctx context.Context, d *schema.ResourceData, client *opal.APIClient, reviewerStagesI any) diag.Diagnostics {
 	rawReviewerStages := reviewerStagesI.([]any)
 	reviewerStages := make([]opal.ReviewerStage, 0, len(rawReviewerStages))
-	for i, rawReviewerStage := range rawReviewerStages {
+	for _, rawReviewerStage := range rawReviewerStages {
 		reviewerStage := rawReviewerStage.(map[string]any)
 		requireManagerApproval := reviewerStage["require_manager_approval"].(bool)
 		operator := reviewerStage["operator"].(string)
@@ -381,7 +381,7 @@ func resourceResourceUpdateReviewerStages(ctx context.Context, d *schema.Resourc
 			return diagFromErr(ctx, err)
 		}
 
-		reviewerStages = append(reviewerStages, *opal.NewReviewerStage(requireManagerApproval, operator, reviewerIds, int32(i+1)))
+		reviewerStages = append(reviewerStages, *opal.NewReviewerStage(requireManagerApproval, operator, reviewerIds))
 		tflog.Debug(ctx, "Setting resource reviewer stage", map[string]any{
 			"id":                     d.Id(),
 			"requireManagerApproval": requireManagerApproval,
@@ -420,7 +420,6 @@ func resourceResourceRead(ctx context.Context, d *schema.ResourceData, m any) di
 		d.Set("recommended_duration", resource.RecommendedDuration),
 		d.Set("request_template_id", resource.RequestTemplateId),
 		d.Set("is_requestable", resource.IsRequestable),
-		// XXX: We don't get the metadata back. Will terraform state be okay?
 	); err.ErrorOrNil() != nil {
 		return diagFromErr(ctx, err)
 	}


### PR DESCRIPTION
## Description of the change

This changes the underlying /owners API being used to allow for querying for owners that contain a `/` in their name as that was previously not working. 

## Checklist

- [x] I performed a self-review of my code
- [x] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
