### PR TITLE
Fix reading requestConfiguration for opal_group

### DIFF
--- a/opal/group.go
+++ b/opal/group.go
@@ -586,6 +586,10 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, m any) diag.
 		d.Set("remote_info", remoteInfoI)
 	}
 
+	if len(requestConfigurations) != 0 {
+		d.Set("request_configuration", requestConfigurations)
+	}
+
 	visibility, _, err := client.GroupsApi.GetGroupVisibility(ctx, group.GroupId).Execute()
 	if err != nil {
 		return diagFromErr(ctx, err)


### PR DESCRIPTION
## Description of the change

The `opal_group` resource did not observe remote changes to `requestConfiguration` field when planning and applying. This fixes that by setting the `request_configurations` field during read similar to the `opal_resource` type: https://github.com/opalsecurity/terraform-provider-opal/blob/b5f14db1793cb0ef90a1285689675a77662b21bf/opal/resource.go#L413-L415 

Tested this change manually against a group whose request configuration had been modified remotely, but terraform reported no change for during plan and apply. After the change, terraform successfully reported changes and applied them:
```
Terraform will perform the following actions:

  # module.app_users.opal_group.group will be updated in-place
  ~ resource "opal_group" "group" {
        id                     = "ffe5d877-3153-485a-902b-9724576ec40f"
        name                   = "#GitHub"
        # (7 unchanged attributes hidden)

      ~ request_configuration {
          ~ auto_approval          = true -> false
            # (7 unchanged attributes hidden)

          + reviewer_stage {
              + operator                 = "OR"
              + require_manager_approval = true
            }
        }

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

I am not sure how to add a unit test for this within terraform's test framework.

## Checklist

- [x] I performed a self-review of my code
- [x] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
