### PR TITLE
Ignore ordering of visibility groups

### DIFF
--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -179,7 +179,7 @@ resource "opal_resource" "github_repo_example" {
 - `require_mfa_to_approve` (Boolean) Require that reviewers MFA to approve requests for this resource.
 - `require_mfa_to_connect` (Boolean) Require that users MFA to connect to this resource. Only applicable for resources where a session can be started from Opal (i.e. AWS RDS database)
 - `visibility` (String) The visibility level of the resource, i.e. LIMITED or GLOBAL.
-- `visibility_group` (Block List) The groups that can see this resource when visibility is limited. If not specified, only admins and users with direct access can see this resource when visibility is set to LIMITED. (see [below for nested schema](#nestedblock--visibility_group))
+- `visibility_group` (Block Set) The groups that can see this resource when visibility is limited. If not specified, only admins and users with direct access can see this resource when visibility is set to LIMITED. (see [below for nested schema](#nestedblock--visibility_group))
 
 ### Read-Only
 

--- a/opal/resource.go
+++ b/opal/resource.go
@@ -147,7 +147,7 @@ func resourceResource() *schema.Resource {
 			},
 			"visibility_group": {
 				Description: "The groups that can see this resource when visibility is limited. If not specified, only admins and users with direct access can see this resource when visibility is set to LIMITED.",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -357,7 +357,7 @@ func resourceResourceUpdateVisibility(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if visibilityGroupI, ok := d.GetOk("visibility_group"); ok {
-		rawGroups := visibilityGroupI.([]any)
+		rawGroups := visibilityGroupI.(*schema.Set).List()
 		groupIds := make([]string, 0, len(rawGroups))
 		for _, rawGroup := range rawGroups {
 			group := rawGroup.(map[string]any)


### PR DESCRIPTION
## Description of the change

The list of visibility groups to apply to a resource is always returned by the API in lexically sorted order by ID. However if you are also creating Opal groups via Terraform, you don't know the ID in advance. This means that `terraform plan` can think that there are always changes to apply, even if it's just changes in 'ordering'.

Of course visibility groups are not an intrinsically ordered concept, so it works better treating it as a Set (so ordering doesn't matter) and just casting back to a list when required to interact with the Opal SDK.

## Testing
We have run create, destroy, and modify tests with visibility groups against our development tenant. We have verified that ordering no longer matters.

## Checklist

- [X] I performed a self-review of my code
- [X] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [X] I updated the public facing docs
