### PR TITLE
[OPAL-9309] Use TypeSet for `visibility_groups` and `group_ids`

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -181,7 +181,7 @@ resource "opal_group" "azure_ad_security_group_example" {
 - `require_mfa_to_approve` (Boolean) Require that reviewers MFA to approve requests for this group.
 - `resource` (Block Set) A resource that members of the group get access to. (see [below for nested schema](#nestedblock--resource))
 - `visibility` (String) The visibility level of the group, i.e. LIMITED or GLOBAL.
-- `visibility_group` (Block List) The groups that can see this group when visibility is limited. If not specified, only users with direct access can see this resource when visibility is set to LIMITED. (see [below for nested schema](#nestedblock--visibility_group))
+- `visibility_group` (Block Set) The groups that can see this group when visibility is limited. If not specified, only users with direct access can see this resource when visibility is set to LIMITED. (see [below for nested schema](#nestedblock--visibility_group))
 
 ### Read-Only
 

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -297,7 +297,7 @@ Required:
 Optional:
 
 - `auto_approval` (Boolean) For users satisfying the condition, automatically approve all requests for this group without review.
-- `group_ids` (List of String) The group IDs satisfying this request configuration. For the default request configuration, this should be empty and priority should be 0, otherwise, this should contain one group ID.
+- `group_ids` (Set of String) The group IDs satisfying this request configuration. For the default request configuration, this should be empty and priority should be 0, otherwise, this should contain one group ID.
 - `is_requestable` (Boolean) For users satisfying the condition, allow them to create an access request for this group. By default, any group is requestable.
 - `max_duration` (Number) For users satisfying the condition, the maximum duration for which this group can be requested (in minutes).
 - `priority` (Number) The priority of this request configuration. The higher the number, the higher the priority. Defaults to 0.

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -179,7 +179,7 @@ resource "opal_resource" "github_repo_example" {
 - `require_mfa_to_approve` (Boolean) Require that reviewers MFA to approve requests for this resource.
 - `require_mfa_to_connect` (Boolean) Require that users MFA to connect to this resource. Only applicable for resources where a session can be started from Opal (i.e. AWS RDS database)
 - `visibility` (String) The visibility level of the resource, i.e. LIMITED or GLOBAL.
-- `visibility_group` (Block List) The groups that can see this resource when visibility is limited. If not specified, only admins and users with direct access can see this resource when visibility is set to LIMITED. (see [below for nested schema](#nestedblock--visibility_group))
+- `visibility_group` (Block Set) The groups that can see this resource when visibility is limited. If not specified, only admins and users with direct access can see this resource when visibility is set to LIMITED. (see [below for nested schema](#nestedblock--visibility_group))
 
 ### Read-Only
 

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -420,7 +420,7 @@ Required:
 Optional:
 
 - `auto_approval` (Boolean) For users satisfying the condition, automatically approve all requests for this resource without review.
-- `group_ids` (List of String) The group IDs satosfying this request configuration. For the default request configuration, this should be empty and priority should be 0, otherwise, this should contain one group ID.
+- `group_ids` (Set of String) The group IDs satisfying this request configuration. For the default request configuration, this should be empty and priority should be 0, otherwise, this should contain one group ID.
 - `is_requestable` (Boolean) For users satisfying the condition, allow the creation an access request for this resource. By default, any resource is requestable.
 - `max_duration` (Number) For users satisfying the condition, the maximum duration for which this resource can be requested (in minutes).
 - `priority` (Number) The priority of this request configuration. The higher the number, the higher the priority. Defaults to 0.

--- a/opal/group.go
+++ b/opal/group.go
@@ -218,7 +218,7 @@ func resourceGroup() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"group_ids": {
 							Description: "The group IDs satisfying this request configuration. For the default request configuration, this should be empty and priority should be 0, otherwise, this should contain one group ID.",
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Optional:    true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,

--- a/opal/group.go
+++ b/opal/group.go
@@ -139,7 +139,7 @@ func resourceGroup() *schema.Resource {
 			},
 			"visibility_group": {
 				Description: "The groups that can see this group when visibility is limited. If not specified, only users with direct access can see this resource when visibility is set to LIMITED.",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -420,7 +420,7 @@ func resourceGroupUpdateVisibility(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if visibilityGroupI, ok := d.GetOk("visibility_group"); ok {
-		rawGroups := visibilityGroupI.([]any)
+		rawGroups := visibilityGroupI.(*schema.Set).List()
 		groupIds := make([]string, 0, len(rawGroups))
 		for _, rawGroup := range rawGroups {
 			group := rawGroup.(map[string]any)

--- a/opal/request_configuration.go
+++ b/opal/request_configuration.go
@@ -3,6 +3,7 @@ package opal
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/opalsecurity/opal-go"
 )
 
@@ -91,7 +92,7 @@ func parseRequestConfiguration(
 	}
 
 	if groupIDsI, ok := requestConfigurationMap["group_ids"]; ok {
-		groupIDsArrayI := groupIDsI.([]interface{})
+		groupIDsArrayI := groupIDsI.(*schema.Set).List()
 		groupIDs := make([]string, len(groupIDsArrayI))
 		for idx, groupIDI := range groupIDsArrayI {
 			groupIDs[idx] = groupIDI.(string)

--- a/opal/resource.go
+++ b/opal/resource.go
@@ -166,8 +166,8 @@ func resourceResource() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"group_ids": {
-							Description: "The group IDs satosfying this request configuration. For the default request configuration, this should be empty and priority should be 0, otherwise, this should contain one group ID.",
-							Type:        schema.TypeList,
+							Description: "The group IDs satisfying this request configuration. For the default request configuration, this should be empty and priority should be 0, otherwise, this should contain one group ID.",
+							Type:        schema.TypeSet,
 							Optional:    true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,

--- a/opal/resource.go
+++ b/opal/resource.go
@@ -147,7 +147,7 @@ func resourceResource() *schema.Resource {
 			},
 			"visibility_group": {
 				Description: "The groups that can see this resource when visibility is limited. If not specified, only admins and users with direct access can see this resource when visibility is set to LIMITED.",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -357,7 +357,7 @@ func resourceResourceUpdateVisibility(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if visibilityGroupI, ok := d.GetOk("visibility_group"); ok {
-		rawGroups := visibilityGroupI.([]any)
+		rawGroups := visibilityGroupI.(*schema.Set).List()
 		groupIds := make([]string, 0, len(rawGroups))
 		for _, rawGroup := range rawGroups {
 			group := rawGroup.(map[string]any)


### PR DESCRIPTION
## Description of the change
Currently, for certain fields, we use `TypeList` which compares order when doing `terraform plan` this diff updates `visibility_groups` in `group` and `resource` as well as `group_ids` in `request_configuration` to be order agnostic, since they are commutative.

## Checklist

- [x] I performed a self-review of my code
- [ ] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [x] I updated the public facing docs
