### PR TITLE
add speakeasy workflow

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,0 +1,13 @@
+workflowVersion: 1.0.0
+sources:
+    opal-terraform-provider:
+        inputs:
+            - location: openapi_original.yaml
+        overlays:
+            - location: terraform_overlay.yaml
+        output: openapi.yaml
+targets:
+    terraform:
+        target: terraform
+        source: opal-terraform-provider
+        output: .


### PR DESCRIPTION
## Description of the change
See: https://github.com/opalsecurity/terraform-provider-opal/pull/45, non-employees couldn't run actions well.

Added support for speakeasy workflow files. https://www.speakeasyapi.dev/docs/workflow-file-reference . Enables complete emulation of the github workflow, including openapi validation, overlay application, and provider compilation locally through `speakeasy run`. No changes to code generation or existing code in the repo. Sample output below. 

![CleanShot 2024-04-15 at 12 48 28@2x](https://github.com/opalsecurity/terraform-provider-opal/assets/68016351/043c2559-f931-41ac-9edf-f99255c1db60)

## Checklist
- [x] I performed a self-review of my code
- [ ] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
