### PR TITLE
[OPAL-11014] Remove spurious TF plan changelogs

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,10 +3,10 @@ id: b5c8bf75-06e1-47c8-b9ae-ce49ba56069d
 management:
   docChecksum: e3cb6b93e32e12628dfa380bb884b5bb
   docVersion: "1.0"
-  speakeasyVersion: 1.295.2
-  generationVersion: 2.335.5
-  releaseVersion: 0.20.3
-  configChecksum: d97df565a07f4d28a63e894c68a76bc0
+  speakeasyVersion: 1.299.3
+  generationVersion: 2.338.7
+  releaseVersion: 0.20.4
+  configChecksum: dc89fa21ba32dd1e7400e48db61f033a
   repoURL: https://github.com/opalsecurity/terraform-provider-opal.git
   repoSubDirectory: .
   published: true
@@ -15,7 +15,7 @@ features:
     additionalDependencies: 0.1.0
     additionalProperties: 0.1.2
     constsAndDefaults: 0.1.4
-    core: 3.21.0
+    core: 3.21.1
     deprecations: 2.81.1
     globalSecurity: 2.81.6
     globalServerURLs: 2.82.1

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,18 +1,17 @@
-speakeasyVersion: 1.295.2
+speakeasyVersion: 1.299.3
 sources:
     opal-terraform-provider:
         sourceNamespace: opal-terraform-provider
-        sourceRevisionDigest: sha256:4607aac498872df8ebaeafe6a96cd40a30fbb6fa4ca216953db3f9eec7309867
-        sourceBlobDigest: sha256:1d6d2919b0f91c1722050a4f6ea1cc45f356a51fec3ac8b6167fa963d59e6080
+        sourceRevisionDigest: sha256:797f36bf99bd287ba390531ea15490eabd31f8f0b5a894e51e401e60b13bdff3
+        sourceBlobDigest: sha256:b5a9fb0beae696e9ed9f3db5c45055b056b59d080c2a6697588de18398f06904
         tags:
             - latest
-            - main
 targets:
     terraform:
         source: opal-terraform-provider
         sourceNamespace: opal-terraform-provider
-        sourceRevisionDigest: sha256:4607aac498872df8ebaeafe6a96cd40a30fbb6fa4ca216953db3f9eec7309867
-        sourceBlobDigest: sha256:1d6d2919b0f91c1722050a4f6ea1cc45f356a51fec3ac8b6167fa963d59e6080
+        sourceRevisionDigest: sha256:797f36bf99bd287ba390531ea15490eabd31f8f0b5a894e51e401e60b13bdff3
+        sourceBlobDigest: sha256:b5a9fb0beae696e9ed9f3db5c45055b056b59d080c2a6697588de18398f06904
         outLocation: .
 workflow:
     workflowVersion: 1.0.0

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     opal = {
       source  = "opalsecurity/opal"
-      version = "0.20.3"
+      version = "0.20.4"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     opal = {
       source  = "opalsecurity/opal"
-      version = "0.20.3"
+      version = "0.20.4"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     opal = {
       source  = "opalsecurity/opal"
-      version = "0.20.3"
+      version = "0.20.4"
     }
   }
 }

--- a/gen.yaml
+++ b/gen.yaml
@@ -12,7 +12,7 @@ generation:
   baseServerURL: ""
   flattenGlobalSecurity: true
 terraform:
-  version: 0.20.3
+  version: 0.20.4
   additionalDataSources: []
   additionalDependencies: {}
   additionalResources: []

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/opalsecurity/terraform-provider-opal
 
 go 1.21
 
-toolchain go1.21.10
+toolchain go1.21.1
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0

--- a/internal/provider/apps_data_source_sdk.go
+++ b/internal/provider/apps_data_source_sdk.go
@@ -10,6 +10,7 @@ import (
 
 func (r *AppsDataSourceModel) RefreshFromSharedAppsList(resp *shared.AppsList) {
 	if resp != nil {
+		r.Apps = []tfTypes.App{}
 		if len(r.Apps) > len(resp.Apps) {
 			r.Apps = r.Apps[:len(resp.Apps)]
 		}

--- a/internal/provider/configurationtemplatelist_data_source_sdk.go
+++ b/internal/provider/configurationtemplatelist_data_source_sdk.go
@@ -10,6 +10,7 @@ import (
 
 func (r *ConfigurationTemplateListDataSourceModel) RefreshFromSharedPaginatedConfigurationTemplateList(resp *shared.PaginatedConfigurationTemplateList) {
 	if resp != nil {
+		r.Results = []tfTypes.ConfigurationTemplate{}
 		if len(r.Results) > len(resp.Results) {
 			r.Results = r.Results[:len(resp.Results)]
 		}

--- a/internal/provider/events_data_source_sdk.go
+++ b/internal/provider/events_data_source_sdk.go
@@ -14,6 +14,7 @@ func (r *EventsDataSourceModel) RefreshFromSharedPaginatedEventList(resp *shared
 	if resp != nil {
 		r.Next = types.StringPointerValue(resp.Next)
 		r.Previous = types.StringPointerValue(resp.Previous)
+		r.Results = []tfTypes.Event{}
 		if len(r.Results) > len(resp.Results) {
 			r.Results = r.Results[:len(resp.Results)]
 		}
@@ -29,6 +30,7 @@ func (r *EventsDataSourceModel) RefreshFromSharedPaginatedEventList(resp *shared
 			results1.CreatedAt = types.StringValue(resultsItem.CreatedAt.Format(time.RFC3339Nano))
 			results1.EventID = types.StringValue(resultsItem.EventID)
 			results1.EventType = types.StringValue(resultsItem.EventType)
+			results1.SubEvents = []tfTypes.SubEvent{}
 			for subEventsCount, subEventsItem := range resultsItem.SubEvents {
 				var subEvents1 tfTypes.SubEvent
 				if subEventsItem.AdditionalProperties == nil {

--- a/internal/provider/group_data_source_sdk.go
+++ b/internal/provider/group_data_source_sdk.go
@@ -86,6 +86,7 @@ func (r *GroupDataSourceModel) RefreshFromSharedGroup(resp *shared.Group) {
 			}
 		}
 		r.RemoteName = types.StringPointerValue(resp.RemoteName)
+		r.RequestConfigurations = []tfTypes.RequestConfiguration{}
 		if len(r.RequestConfigurations) > len(resp.RequestConfigurations) {
 			r.RequestConfigurations = r.RequestConfigurations[:len(resp.RequestConfigurations)]
 		}
@@ -112,6 +113,7 @@ func (r *GroupDataSourceModel) RefreshFromSharedGroup(resp *shared.Group) {
 			requestConfigurations1.RequestTemplateID = types.StringPointerValue(requestConfigurationsItem.RequestTemplateID)
 			requestConfigurations1.RequireMfaToRequest = types.BoolValue(requestConfigurationsItem.RequireMfaToRequest)
 			requestConfigurations1.RequireSupportTicket = types.BoolValue(requestConfigurationsItem.RequireSupportTicket)
+			requestConfigurations1.ReviewerStages = []tfTypes.ReviewerStage{}
 			for reviewerStagesCount, reviewerStagesItem := range requestConfigurationsItem.ReviewerStages {
 				var reviewerStages1 tfTypes.ReviewerStage
 				if reviewerStagesItem.Operator != nil {
@@ -155,6 +157,7 @@ func (r *GroupDataSourceModel) RefreshFromSharedGroup(resp *shared.Group) {
 
 func (r *GroupDataSourceModel) RefreshFromOperationsGetGroupMessageChannelsResponseBody(resp *operations.GetGroupMessageChannelsResponseBody) {
 	if resp != nil {
+		r.MessageChannels.Channels = []tfTypes.MessageChannel{}
 		if len(r.MessageChannels.Channels) > len(resp.Channels) {
 			r.MessageChannels.Channels = r.MessageChannels.Channels[:len(resp.Channels)]
 		}

--- a/internal/provider/group_list_data_source_sdk.go
+++ b/internal/provider/group_list_data_source_sdk.go
@@ -10,6 +10,7 @@ import (
 
 func (r *GroupListDataSourceModel) RefreshFromSharedPaginatedGroupsList(resp *shared.PaginatedGroupsList) {
 	if resp != nil {
+		r.Results = []tfTypes.Group{}
 		if len(r.Results) > len(resp.Results) {
 			r.Results = r.Results[:len(resp.Results)]
 		}
@@ -90,6 +91,7 @@ func (r *GroupListDataSourceModel) RefreshFromSharedPaginatedGroupsList(resp *sh
 				}
 			}
 			results1.RemoteName = types.StringPointerValue(resultsItem.RemoteName)
+			results1.RequestConfigurations = []tfTypes.RequestConfiguration{}
 			for requestConfigurationsCount, requestConfigurationsItem := range resultsItem.RequestConfigurations {
 				var requestConfigurations1 tfTypes.RequestConfiguration
 				requestConfigurations1.AllowRequests = types.BoolValue(requestConfigurationsItem.AllowRequests)
@@ -113,6 +115,7 @@ func (r *GroupListDataSourceModel) RefreshFromSharedPaginatedGroupsList(resp *sh
 				requestConfigurations1.RequestTemplateID = types.StringPointerValue(requestConfigurationsItem.RequestTemplateID)
 				requestConfigurations1.RequireMfaToRequest = types.BoolValue(requestConfigurationsItem.RequireMfaToRequest)
 				requestConfigurations1.RequireSupportTicket = types.BoolValue(requestConfigurationsItem.RequireSupportTicket)
+				requestConfigurations1.ReviewerStages = []tfTypes.ReviewerStage{}
 				for reviewerStagesCount, reviewerStagesItem := range requestConfigurationsItem.ReviewerStages {
 					var reviewerStages1 tfTypes.ReviewerStage
 					if reviewerStagesItem.Operator != nil {

--- a/internal/provider/group_resource_sdk.go
+++ b/internal/provider/group_resource_sdk.go
@@ -183,6 +183,7 @@ func (r *GroupResourceModel) RefreshFromSharedGroup(resp *shared.Group) {
 			}
 		}
 		r.RemoteName = types.StringPointerValue(resp.RemoteName)
+		r.RequestConfigurations = []tfTypes.RequestConfiguration{}
 		if len(r.RequestConfigurations) > len(resp.RequestConfigurations) {
 			r.RequestConfigurations = r.RequestConfigurations[:len(resp.RequestConfigurations)]
 		}
@@ -209,6 +210,7 @@ func (r *GroupResourceModel) RefreshFromSharedGroup(resp *shared.Group) {
 			requestConfigurations1.RequestTemplateID = types.StringPointerValue(requestConfigurationsItem.RequestTemplateID)
 			requestConfigurations1.RequireMfaToRequest = types.BoolValue(requestConfigurationsItem.RequireMfaToRequest)
 			requestConfigurations1.RequireSupportTicket = types.BoolValue(requestConfigurationsItem.RequireSupportTicket)
+			requestConfigurations1.ReviewerStages = []tfTypes.ReviewerStage{}
 			for reviewerStagesCount, reviewerStagesItem := range requestConfigurationsItem.ReviewerStages {
 				var reviewerStages1 tfTypes.ReviewerStage
 				if reviewerStagesItem.Operator != nil {
@@ -385,6 +387,7 @@ func (r *GroupResourceModel) RefreshFromSharedUpdateGroupInfo(resp shared.Update
 	}
 	r.ID = types.StringPointerValue(resp.ID)
 	r.Name = types.StringPointerValue(resp.Name)
+	r.RequestConfigurations = []tfTypes.RequestConfiguration{}
 	if len(r.RequestConfigurations) > len(resp.RequestConfigurations) {
 		r.RequestConfigurations = r.RequestConfigurations[:len(resp.RequestConfigurations)]
 	}
@@ -411,6 +414,7 @@ func (r *GroupResourceModel) RefreshFromSharedUpdateGroupInfo(resp shared.Update
 		requestConfigurations1.RequestTemplateID = types.StringPointerValue(requestConfigurationsItem.RequestTemplateID)
 		requestConfigurations1.RequireMfaToRequest = types.BoolValue(requestConfigurationsItem.RequireMfaToRequest)
 		requestConfigurations1.RequireSupportTicket = types.BoolValue(requestConfigurationsItem.RequireSupportTicket)
+		requestConfigurations1.ReviewerStages = []tfTypes.ReviewerStage{}
 		for reviewerStagesCount, reviewerStagesItem := range requestConfigurationsItem.ReviewerStages {
 			var reviewerStages1 tfTypes.ReviewerStage
 			if reviewerStagesItem.Operator != nil {
@@ -477,6 +481,7 @@ func (r *GroupResourceModel) ToSharedVisibilityInfo() *shared.VisibilityInfo {
 
 func (r *GroupResourceModel) RefreshFromOperationsGetGroupMessageChannelsResponseBody(resp *operations.GetGroupMessageChannelsResponseBody) {
 	if resp != nil {
+		r.MessageChannels.Channels = []tfTypes.MessageChannel{}
 		if len(r.MessageChannels.Channels) > len(resp.Channels) {
 			r.MessageChannels.Channels = r.MessageChannels.Channels[:len(resp.Channels)]
 		}

--- a/internal/provider/groupresourcelist_data_source_sdk.go
+++ b/internal/provider/groupresourcelist_data_source_sdk.go
@@ -10,6 +10,7 @@ import (
 
 func (r *GroupResourceListDataSourceModel) RefreshFromSharedGroupResourceList(resp *shared.GroupResourceList) {
 	if resp != nil {
+		r.GroupResources = []tfTypes.GroupResource1{}
 		if len(r.GroupResources) > len(resp.GroupResources) {
 			r.GroupResources = r.GroupResources[:len(resp.GroupResources)]
 		}

--- a/internal/provider/groupresourcelist_resource_sdk.go
+++ b/internal/provider/groupresourcelist_resource_sdk.go
@@ -31,6 +31,7 @@ func (r *GroupResourceListResourceModel) ToSharedUpdateGroupResourcesInfo() *sha
 
 func (r *GroupResourceListResourceModel) RefreshFromSharedGroupResourceList(resp *shared.GroupResourceList) {
 	if resp != nil {
+		r.GroupResources = []tfTypes.GroupResource1{}
 		if len(r.GroupResources) > len(resp.GroupResources) {
 			r.GroupResources = r.GroupResources[:len(resp.GroupResources)]
 		}

--- a/internal/provider/groupreviewersstageslist_data_source_sdk.go
+++ b/internal/provider/groupreviewersstageslist_data_source_sdk.go
@@ -9,6 +9,7 @@ import (
 )
 
 func (r *GroupReviewersStagesListDataSourceModel) RefreshFromSharedReviewerStage(resp []shared.ReviewerStage) {
+	r.Data = []tfTypes.ReviewerStage{}
 	if len(r.Data) > len(resp) {
 		r.Data = r.Data[:len(resp)]
 	}

--- a/internal/provider/grouptags_data_source_sdk.go
+++ b/internal/provider/grouptags_data_source_sdk.go
@@ -11,6 +11,7 @@ import (
 
 func (r *GroupTagsDataSourceModel) RefreshFromSharedTagsList(resp *shared.TagsList) {
 	if resp != nil {
+		r.Tags = []tfTypes.Tag{}
 		if len(r.Tags) > len(resp.Tags) {
 			r.Tags = r.Tags[:len(resp.Tags)]
 		}

--- a/internal/provider/groupusers_data_source_sdk.go
+++ b/internal/provider/groupusers_data_source_sdk.go
@@ -11,6 +11,7 @@ import (
 
 func (r *GroupUsersDataSourceModel) RefreshFromSharedGroupUserList(resp *shared.GroupUserList) {
 	if resp != nil {
+		r.Results = []tfTypes.GroupUser{}
 		if len(r.Results) > len(resp.Results) {
 			r.Results = r.Results[:len(resp.Results)]
 		}

--- a/internal/provider/messagechannellist_data_source_sdk.go
+++ b/internal/provider/messagechannellist_data_source_sdk.go
@@ -10,6 +10,7 @@ import (
 
 func (r *MessageChannelListDataSourceModel) RefreshFromSharedMessageChannelList(resp *shared.MessageChannelList) {
 	if resp != nil {
+		r.Channels = []tfTypes.MessageChannel{}
 		if len(r.Channels) > len(resp.Channels) {
 			r.Channels = r.Channels[:len(resp.Channels)]
 		}

--- a/internal/provider/oncallschedule_list_data_source_sdk.go
+++ b/internal/provider/oncallschedule_list_data_source_sdk.go
@@ -10,6 +10,7 @@ import (
 
 func (r *OnCallScheduleListDataSourceModel) RefreshFromSharedOnCallScheduleList(resp *shared.OnCallScheduleList) {
 	if resp != nil {
+		r.OnCallSchedules = []tfTypes.GetGroupOnCallSchedulesResponseBody{}
 		if len(r.OnCallSchedules) > len(resp.OnCallSchedules) {
 			r.OnCallSchedules = r.OnCallSchedules[:len(resp.OnCallSchedules)]
 		}

--- a/internal/provider/owners_data_source_sdk.go
+++ b/internal/provider/owners_data_source_sdk.go
@@ -12,6 +12,7 @@ func (r *OwnersDataSourceModel) RefreshFromSharedPaginatedOwnersList(resp *share
 	if resp != nil {
 		r.Next = types.StringPointerValue(resp.Next)
 		r.Previous = types.StringPointerValue(resp.Previous)
+		r.Results = []tfTypes.Owner{}
 		if len(r.Results) > len(resp.Results) {
 			r.Results = r.Results[:len(resp.Results)]
 		}

--- a/internal/provider/requests_data_source_sdk.go
+++ b/internal/provider/requests_data_source_sdk.go
@@ -12,12 +12,14 @@ import (
 func (r *RequestsDataSourceModel) RefreshFromSharedRequestList(resp *shared.RequestList) {
 	if resp != nil {
 		r.Cursor = types.StringPointerValue(resp.Cursor)
+		r.Requests = []tfTypes.Request{}
 		if len(r.Requests) > len(resp.Requests) {
 			r.Requests = r.Requests[:len(resp.Requests)]
 		}
 		for requestsCount, requestsItem := range resp.Requests {
 			var requests1 tfTypes.Request
 			requests1.CreatedAt = types.StringValue(requestsItem.CreatedAt.Format(time.RFC3339Nano))
+			requests1.CustomFieldsResponses = []tfTypes.RequestCustomFieldResponse{}
 			for customFieldsResponsesCount, customFieldsResponsesItem := range requestsItem.CustomFieldsResponses {
 				var customFieldsResponses1 tfTypes.RequestCustomFieldResponse
 				customFieldsResponses1.FieldName = types.StringValue(customFieldsResponsesItem.FieldName)
@@ -39,6 +41,7 @@ func (r *RequestsDataSourceModel) RefreshFromSharedRequestList(resp *shared.Requ
 			requests1.DurationMinutes = types.Int64PointerValue(requestsItem.DurationMinutes)
 			requests1.ID = types.StringValue(requestsItem.ID)
 			requests1.Reason = types.StringValue(requestsItem.Reason)
+			requests1.RequestedItemsList = []tfTypes.RequestedItem{}
 			for requestedItemsListCount, requestedItemsListItem := range requestsItem.RequestedItemsList {
 				var requestedItemsList1 tfTypes.RequestedItem
 				requestedItemsList1.AccessLevelName = types.StringPointerValue(requestedItemsListItem.AccessLevelName)

--- a/internal/provider/resource_data_source_sdk.go
+++ b/internal/provider/resource_data_source_sdk.go
@@ -186,6 +186,7 @@ func (r *ResourceDataSourceModel) RefreshFromSharedResource(resp *shared.Resourc
 				r.RemoteInfo.TeleportRole.RoleName = types.StringValue(resp.RemoteInfo.TeleportRole.RoleName)
 			}
 		}
+		r.RequestConfigurations = []tfTypes.RequestConfiguration{}
 		if len(r.RequestConfigurations) > len(resp.RequestConfigurations) {
 			r.RequestConfigurations = r.RequestConfigurations[:len(resp.RequestConfigurations)]
 		}
@@ -212,6 +213,7 @@ func (r *ResourceDataSourceModel) RefreshFromSharedResource(resp *shared.Resourc
 			requestConfigurations1.RequestTemplateID = types.StringPointerValue(requestConfigurationsItem.RequestTemplateID)
 			requestConfigurations1.RequireMfaToRequest = types.BoolValue(requestConfigurationsItem.RequireMfaToRequest)
 			requestConfigurations1.RequireSupportTicket = types.BoolValue(requestConfigurationsItem.RequireSupportTicket)
+			requestConfigurations1.ReviewerStages = []tfTypes.ReviewerStage{}
 			for reviewerStagesCount, reviewerStagesItem := range requestConfigurationsItem.ReviewerStages {
 				var reviewerStages1 tfTypes.ReviewerStage
 				if reviewerStagesItem.Operator != nil {

--- a/internal/provider/resource_resource_sdk.go
+++ b/internal/provider/resource_resource_sdk.go
@@ -461,6 +461,7 @@ func (r *ResourceResourceModel) RefreshFromSharedResource(resp *shared.Resource)
 				r.RemoteInfo.TeleportRole.RoleName = types.StringValue(resp.RemoteInfo.TeleportRole.RoleName)
 			}
 		}
+		r.RequestConfigurations = []tfTypes.RequestConfiguration{}
 		if len(r.RequestConfigurations) > len(resp.RequestConfigurations) {
 			r.RequestConfigurations = r.RequestConfigurations[:len(resp.RequestConfigurations)]
 		}
@@ -487,6 +488,7 @@ func (r *ResourceResourceModel) RefreshFromSharedResource(resp *shared.Resource)
 			requestConfigurations1.RequestTemplateID = types.StringPointerValue(requestConfigurationsItem.RequestTemplateID)
 			requestConfigurations1.RequireMfaToRequest = types.BoolValue(requestConfigurationsItem.RequireMfaToRequest)
 			requestConfigurations1.RequireSupportTicket = types.BoolValue(requestConfigurationsItem.RequireSupportTicket)
+			requestConfigurations1.ReviewerStages = []tfTypes.ReviewerStage{}
 			for reviewerStagesCount, reviewerStagesItem := range requestConfigurationsItem.ReviewerStages {
 				var reviewerStages1 tfTypes.ReviewerStage
 				if reviewerStagesItem.Operator != nil {
@@ -667,6 +669,7 @@ func (r *ResourceResourceModel) RefreshFromSharedUpdateResourceInfo(resp shared.
 	r.Description = types.StringPointerValue(resp.Description)
 	r.ID = types.StringPointerValue(resp.ID)
 	r.Name = types.StringPointerValue(resp.Name)
+	r.RequestConfigurations = []tfTypes.RequestConfiguration{}
 	if len(r.RequestConfigurations) > len(resp.RequestConfigurations) {
 		r.RequestConfigurations = r.RequestConfigurations[:len(resp.RequestConfigurations)]
 	}
@@ -693,6 +696,7 @@ func (r *ResourceResourceModel) RefreshFromSharedUpdateResourceInfo(resp shared.
 		requestConfigurations1.RequestTemplateID = types.StringPointerValue(requestConfigurationsItem.RequestTemplateID)
 		requestConfigurations1.RequireMfaToRequest = types.BoolValue(requestConfigurationsItem.RequireMfaToRequest)
 		requestConfigurations1.RequireSupportTicket = types.BoolValue(requestConfigurationsItem.RequireSupportTicket)
+		requestConfigurations1.ReviewerStages = []tfTypes.ReviewerStage{}
 		for reviewerStagesCount, reviewerStagesItem := range requestConfigurationsItem.ReviewerStages {
 			var reviewerStages1 tfTypes.ReviewerStage
 			if reviewerStagesItem.Operator != nil {

--- a/internal/provider/resourcemessagechannellist_data_source_sdk.go
+++ b/internal/provider/resourcemessagechannellist_data_source_sdk.go
@@ -10,6 +10,7 @@ import (
 
 func (r *ResourceMessageChannelListDataSourceModel) RefreshFromSharedMessageChannelList(resp *shared.MessageChannelList) {
 	if resp != nil {
+		r.Channels = []tfTypes.MessageChannel{}
 		if len(r.Channels) > len(resp.Channels) {
 			r.Channels = r.Channels[:len(resp.Channels)]
 		}

--- a/internal/provider/resources_list_data_source_sdk.go
+++ b/internal/provider/resources_list_data_source_sdk.go
@@ -12,6 +12,7 @@ func (r *ResourcesListDataSourceModel) RefreshFromSharedPaginatedResourcesList(r
 	if resp != nil {
 		r.Next = types.StringPointerValue(resp.Next)
 		r.Previous = types.StringPointerValue(resp.Previous)
+		r.Results = []tfTypes.Resource{}
 		if len(r.Results) > len(resp.Results) {
 			r.Results = r.Results[:len(resp.Results)]
 		}
@@ -193,6 +194,7 @@ func (r *ResourcesListDataSourceModel) RefreshFromSharedPaginatedResourcesList(r
 					results1.RemoteInfo.TeleportRole.RoleName = types.StringValue(resultsItem.RemoteInfo.TeleportRole.RoleName)
 				}
 			}
+			results1.RequestConfigurations = []tfTypes.RequestConfiguration{}
 			for requestConfigurationsCount, requestConfigurationsItem := range resultsItem.RequestConfigurations {
 				var requestConfigurations1 tfTypes.RequestConfiguration
 				requestConfigurations1.AllowRequests = types.BoolValue(requestConfigurationsItem.AllowRequests)
@@ -216,6 +218,7 @@ func (r *ResourcesListDataSourceModel) RefreshFromSharedPaginatedResourcesList(r
 				requestConfigurations1.RequestTemplateID = types.StringPointerValue(requestConfigurationsItem.RequestTemplateID)
 				requestConfigurations1.RequireMfaToRequest = types.BoolValue(requestConfigurationsItem.RequireMfaToRequest)
 				requestConfigurations1.RequireSupportTicket = types.BoolValue(requestConfigurationsItem.RequireSupportTicket)
+				requestConfigurations1.ReviewerStages = []tfTypes.ReviewerStage{}
 				for reviewerStagesCount, reviewerStagesItem := range requestConfigurationsItem.ReviewerStages {
 					var reviewerStages1 tfTypes.ReviewerStage
 					if reviewerStagesItem.Operator != nil {

--- a/internal/provider/resourcesusers_list_data_source_sdk.go
+++ b/internal/provider/resourcesusers_list_data_source_sdk.go
@@ -11,6 +11,7 @@ import (
 
 func (r *ResourcesUsersListDataSourceModel) RefreshFromSharedResourceAccessUserList(resp *shared.ResourceAccessUserList) {
 	if resp != nil {
+		r.Results = []tfTypes.ResourceAccessUser{}
 		if len(r.Results) > len(resp.Results) {
 			r.Results = r.Results[:len(resp.Results)]
 		}

--- a/internal/provider/resourcetags_data_source_sdk.go
+++ b/internal/provider/resourcetags_data_source_sdk.go
@@ -11,6 +11,7 @@ import (
 
 func (r *ResourceTagsDataSourceModel) RefreshFromSharedTagsList(resp *shared.TagsList) {
 	if resp != nil {
+		r.Tags = []tfTypes.Tag{}
 		if len(r.Tags) > len(resp.Tags) {
 			r.Tags = r.Tags[:len(resp.Tags)]
 		}

--- a/internal/provider/sessions_data_source_sdk.go
+++ b/internal/provider/sessions_data_source_sdk.go
@@ -13,6 +13,7 @@ func (r *SessionsDataSourceModel) RefreshFromSharedSessionsList(resp *shared.Ses
 	if resp != nil {
 		r.Next = types.StringPointerValue(resp.Next)
 		r.Previous = types.StringPointerValue(resp.Previous)
+		r.Results = []tfTypes.Session{}
 		if len(r.Results) > len(resp.Results) {
 			r.Results = r.Results[:len(resp.Results)]
 		}

--- a/internal/provider/tags_list_data_source_sdk.go
+++ b/internal/provider/tags_list_data_source_sdk.go
@@ -13,6 +13,7 @@ func (r *TagsListDataSourceModel) RefreshFromSharedPaginatedTagsList(resp *share
 	if resp != nil {
 		r.Next = types.StringPointerValue(resp.Next)
 		r.Previous = types.StringPointerValue(resp.Previous)
+		r.Results = []tfTypes.Tag{}
 		if len(r.Results) > len(resp.Results) {
 			r.Results = r.Results[:len(resp.Results)]
 		}

--- a/internal/provider/uar_data_source_sdk.go
+++ b/internal/provider/uar_data_source_sdk.go
@@ -56,6 +56,7 @@ func (r *UarDataSourceModel) RefreshFromSharedUar(resp *shared.Uar) {
 			for _, v := range resp.UarScope.ResourceTypes {
 				r.UarScope.ResourceTypes = append(r.UarScope.ResourceTypes, types.StringValue(string(v)))
 			}
+			r.UarScope.Tags = []tfTypes.TagFilter{}
 			if len(r.UarScope.Tags) > len(resp.UarScope.Tags) {
 				r.UarScope.Tags = r.UarScope.Tags[:len(resp.UarScope.Tags)]
 			}

--- a/internal/provider/uars_list_data_source_sdk.go
+++ b/internal/provider/uars_list_data_source_sdk.go
@@ -13,6 +13,7 @@ func (r *UARSListDataSourceModel) RefreshFromSharedPaginatedUARsList(resp *share
 	if resp != nil {
 		r.Next = types.StringPointerValue(resp.Next)
 		r.Previous = types.StringPointerValue(resp.Previous)
+		r.Results = []tfTypes.Uar{}
 		if len(r.Results) > len(resp.Results) {
 			r.Results = r.Results[:len(resp.Results)]
 		}
@@ -64,6 +65,7 @@ func (r *UARSListDataSourceModel) RefreshFromSharedPaginatedUARsList(resp *share
 				for _, v := range resultsItem.UarScope.ResourceTypes {
 					results1.UarScope.ResourceTypes = append(results1.UarScope.ResourceTypes, types.StringValue(string(v)))
 				}
+				results1.UarScope.Tags = []tfTypes.TagFilter{}
 				for tagsCount, tagsItem := range resultsItem.UarScope.Tags {
 					var tags1 tfTypes.TagFilter
 					tags1.Key = types.StringValue(tagsItem.Key)

--- a/internal/provider/users_data_source_sdk.go
+++ b/internal/provider/users_data_source_sdk.go
@@ -12,6 +12,7 @@ func (r *UsersDataSourceModel) RefreshFromSharedPaginatedUsersList(resp *shared.
 	if resp != nil {
 		r.Next = types.StringPointerValue(resp.Next)
 		r.Previous = types.StringPointerValue(resp.Previous)
+		r.Results = []tfTypes.User{}
 		if len(r.Results) > len(resp.Results) {
 			r.Results = r.Results[:len(resp.Results)]
 		}

--- a/internal/provider/usertags_data_source_sdk.go
+++ b/internal/provider/usertags_data_source_sdk.go
@@ -11,6 +11,7 @@ import (
 
 func (r *UserTagsDataSourceModel) RefreshFromSharedTagsList(resp *shared.TagsList) {
 	if resp != nil {
+		r.Tags = []tfTypes.Tag{}
 		if len(r.Tags) > len(resp.Tags) {
 			r.Tags = r.Tags[:len(resp.Tags)]
 		}

--- a/internal/sdk/opalapi.go
+++ b/internal/sdk/opalapi.go
@@ -172,8 +172,8 @@ func New(opts ...SDKOption) *OpalAPI {
 			Language:          "go",
 			OpenAPIDocVersion: "1.0",
 			SDKVersion:        "0.0.1",
-			GenVersion:        "2.335.5",
-			UserAgent:         "speakeasy-sdk/go 0.0.1 2.335.5 1.0 github.com/opalsecurity/terraform-provider-opal/internal/sdk",
+			GenVersion:        "2.338.7",
+			UserAgent:         "speakeasy-sdk/go 0.0.1 2.338.7 1.0 github.com/opalsecurity/terraform-provider-opal/internal/sdk",
 			Hooks:             hooks.New(),
 		},
 	}


### PR DESCRIPTION
## Description of the change
We used to flag non-changes as changes in TF plan, this updates the Speakeasy version and re-runs autogen

## Checklist
- [ ] I performed a self-review of my code
- [ ] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
