### PR TITLE
Bump goreleaser action to v6 from v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.1.0
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
## Description of the change
After being forced to run goreleaser with "--clean", the action failed with a comment saying a `version 2` config is needed which was introduced at some later version of the goreleaser action. This just updates to the latest major version so we can  unblock our terraform package publishing.

