### PR TITLE
Set terraform provider to use OPAL_AUTH_TOKEN envar as bearer…

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,10 +3,10 @@ id: b5c8bf75-06e1-47c8-b9ae-ce49ba56069d
 management:
   docChecksum: a107ffd47833df714c17fbb8f44eb9c0
   docVersion: "1.0"
-  speakeasyVersion: 1.344.2
-  generationVersion: 2.377.1
-  releaseVersion: 0.23.0
-  configChecksum: 04608bbdbcc98f993d4309aa058b6484
+  speakeasyVersion: 1.345.3
+  generationVersion: 2.378.3
+  releaseVersion: 0.23.1
+  configChecksum: b6a0270266465815fae95e0a1038eca3
   repoURL: https://github.com/opalsecurity/terraform-provider-opal.git
   repoSubDirectory: .
   published: true
@@ -15,7 +15,7 @@ features:
     additionalDependencies: 0.1.0
     additionalProperties: 0.1.2
     constsAndDefaults: 0.1.4
-    core: 3.24.1
+    core: 3.24.2
     deprecations: 2.81.1
     globalSecurity: 2.81.6
     globalServerURLs: 2.82.1

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,8 +1,8 @@
-speakeasyVersion: 1.344.2
+speakeasyVersion: 1.345.3
 sources:
     opal-terraform-provider:
         sourceNamespace: opal-terraform-provider
-        sourceRevisionDigest: sha256:faa79cb2eee4d0657309701ae709eb26913a83bf9b7af7df4e6fb1a1bfc4cde4
+        sourceRevisionDigest: sha256:fe19f5356675f1f897227b4f8ab1411ecc32b41f2d4d0e676d9c79a4afd87812
         sourceBlobDigest: sha256:66b70d74e51f3898206042823c9b7a5feb55bd42f22f6a9d94c7856d6f8c8f55
         tags:
             - latest
@@ -10,7 +10,7 @@ targets:
     terraform:
         source: opal-terraform-provider
         sourceNamespace: opal-terraform-provider
-        sourceRevisionDigest: sha256:faa79cb2eee4d0657309701ae709eb26913a83bf9b7af7df4e6fb1a1bfc4cde4
+        sourceRevisionDigest: sha256:fe19f5356675f1f897227b4f8ab1411ecc32b41f2d4d0e676d9c79a4afd87812
         sourceBlobDigest: sha256:66b70d74e51f3898206042823c9b7a5feb55bd42f22f6a9d94c7856d6f8c8f55
         outLocation: .
 workflow:

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     opal = {
       source  = "opalsecurity/opal"
-      version = "0.23.0"
+      version = "0.23.1"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     opal = {
       source  = "opalsecurity/opal"
-      version = "0.23.0"
+      version = "0.23.1"
     }
   }
 }

--- a/gen.yaml
+++ b/gen.yaml
@@ -9,16 +9,17 @@ generation:
     requestResponseComponentNamesFeb2024: false
   auth:
     oAuth2ClientCredentialsEnabled: false
-  baseServerURL: ""
   flattenGlobalSecurity: true
 terraform:
-  version: 0.23.0
+  version: 0.23.1
   additionalDataSources: []
   additionalDependencies: {}
   additionalResources: []
   allowUnknownFieldsInWeakUnions: false
   author: opalsecurity
-  environmentVariables: []
+  environmentVariables:
+    - env: OPAL_AUTH_TOKEN
+      providerAttribute: bearer_auth
   imports:
     option: openapi
     paths:

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-testing v1.9.0
+	github.com/pkg/errors v0.9.1
 )
 
 require (
@@ -58,7 +59,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opalsecurity/terraform-provider-opal/internal/sdk"
 	"github.com/opalsecurity/terraform-provider-opal/internal/sdk/models/shared"
 	"net/http"
+	"os"
 )
 
 var _ provider.Provider = &OpalProvider{}
@@ -70,7 +71,11 @@ func (p *OpalProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	if !data.BearerAuth.IsUnknown() && !data.BearerAuth.IsNull() {
 		*bearerAuth = data.BearerAuth.ValueString()
 	} else {
-		bearerAuth = nil
+		if len(os.Getenv("OPAL_AUTH_TOKEN")) > 0 {
+			*bearerAuth = os.Getenv("OPAL_AUTH_TOKEN")
+		} else {
+			bearerAuth = nil
+		}
 	}
 	security := shared.Security{
 		BearerAuth: bearerAuth,

--- a/internal/sdk/internal/utils/queryparams.go
+++ b/internal/sdk/internal/utils/queryparams.go
@@ -18,6 +18,11 @@ import (
 )
 
 func PopulateQueryParams(_ context.Context, req *http.Request, queryParams interface{}, globals interface{}) error {
+	// Query parameters may already be present from overriding URL
+	if req.URL.RawQuery != "" {
+		return nil
+	}
+
 	values := url.Values{}
 
 	globalsAlreadyPopulated, err := populateQueryParams(queryParams, globals, values, []string{})

--- a/internal/sdk/models/operations/options.go
+++ b/internal/sdk/models/operations/options.go
@@ -16,6 +16,7 @@ const (
 	SupportedOptionRetries              = "retries"
 	SupportedOptionTimeout              = "timeout"
 	SupportedOptionAcceptHeaderOverride = "acceptHeaderOverride"
+	SupportedOptionURLOverride          = "urlOverride"
 )
 
 type AcceptHeaderEnum string
@@ -34,6 +35,7 @@ type Options struct {
 	Retries              *retry.Config
 	Timeout              *time.Duration
 	AcceptHeaderOverride *AcceptHeaderEnum
+	URLOverride          *string
 }
 
 type Option func(*Options, ...string) error
@@ -97,6 +99,18 @@ func WithAcceptHeaderOverride(acceptHeaderOverride AcceptHeaderEnum) Option {
 		}
 
 		opts.AcceptHeaderOverride = &acceptHeaderOverride
+		return nil
+	}
+}
+
+// WithURLOverride allows overriding the URL.
+func WithURLOverride(urlOverride string) Option {
+	return func(opts *Options, supportedOptions ...string) error {
+		if !utils.Contains(supportedOptions, SupportedOptionURLOverride) {
+			return ErrUnsupportedOption
+		}
+
+		opts.URLOverride = &urlOverride
 		return nil
 	}
 }

--- a/internal/sdk/opalapi.go
+++ b/internal/sdk/opalapi.go
@@ -181,8 +181,8 @@ func New(opts ...SDKOption) *OpalAPI {
 			Language:          "go",
 			OpenAPIDocVersion: "1.0",
 			SDKVersion:        "0.0.1",
-			GenVersion:        "2.377.1",
-			UserAgent:         "speakeasy-sdk/go 0.0.1 2.377.1 1.0 github.com/opalsecurity/terraform-provider-opal/internal/sdk",
+			GenVersion:        "2.378.3",
+			UserAgent:         "speakeasy-sdk/go 0.0.1 2.378.3 1.0 github.com/opalsecurity/terraform-provider-opal/internal/sdk",
 			Hooks:             hooks.New(),
 		},
 	}


### PR DESCRIPTION
…_auth to provider.

## Description of the change
Goal is to make it easier for folks to use terraform provider since they'll want to pass the envar to the provider without having to explicitly state a terraform variable.

> Write a brief description of your change here. 

## Checklist

- [x] I performed a self-review of my code
- [x] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
