### PR TITLE
add computed annotation to the result of the oncallschedules GET

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: b5c8bf75-06e1-47c8-b9ae-ce49ba56069d
 management:
-  docChecksum: a107ffd47833df714c17fbb8f44eb9c0
+  docChecksum: 5daed4c9f71bbd24fb1edcfc76773b3e
   docVersion: "1.0"
-  speakeasyVersion: 1.352.2
-  generationVersion: 2.385.2
-  releaseVersion: 0.24.0
-  configChecksum: e434993130d9af19734fdb89d4ace9dc
+  speakeasyVersion: 1.357.2
+  generationVersion: 2.390.0
+  releaseVersion: 0.24.1
+  configChecksum: 9e09c53a463983648dfa0e1093924754
   repoURL: https://github.com/opalsecurity/terraform-provider-opal.git
   repoSubDirectory: .
   published: true

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,17 +1,17 @@
-speakeasyVersion: 1.352.2
+speakeasyVersion: 1.357.2
 sources:
     opal-terraform-provider:
         sourceNamespace: opal-terraform-provider
-        sourceRevisionDigest: sha256:5a5431e90e6bfc1d8b390535469fce11d87690d718a91c0329e65500874d6de5
-        sourceBlobDigest: sha256:86b9ddd85104869419ff2b39c734475e8343b5faea5af83f20ccc4a5c482876c
+        sourceRevisionDigest: sha256:d02e1065ee2374fe3473e6c0012efe2bbc61bc5714057a82b9b83becfecf8605
+        sourceBlobDigest: sha256:f40cfb942fb5f591ee72e7733b91d943a26f39f106e1c8d976027a0d83e493f7
         tags:
             - latest
 targets:
     terraform:
         source: opal-terraform-provider
         sourceNamespace: opal-terraform-provider
-        sourceRevisionDigest: sha256:5a5431e90e6bfc1d8b390535469fce11d87690d718a91c0329e65500874d6de5
-        sourceBlobDigest: sha256:86b9ddd85104869419ff2b39c734475e8343b5faea5af83f20ccc4a5c482876c
+        sourceRevisionDigest: sha256:d02e1065ee2374fe3473e6c0012efe2bbc61bc5714057a82b9b83becfecf8605
+        sourceBlobDigest: sha256:f40cfb942fb5f591ee72e7733b91d943a26f39f106e1c8d976027a0d83e493f7
         outLocation: .
 workflow:
     workflowVersion: 1.0.0

--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -14,7 +14,7 @@ Group DataSource
 
 ```terraform
 data "opal_group" "my_group" {
-  id = "32acc112-21ff-4669-91c2-21e27683eaa1"
+  id = "f454d283-ca87-4a8a-bdbb-df212eca5353"
 }
 ```
 

--- a/docs/data-sources/message_channel.md
+++ b/docs/data-sources/message_channel.md
@@ -14,7 +14,7 @@ MessageChannel DataSource
 
 ```terraform
 data "opal_message_channel" "my_messagechannel" {
-  id = "4baf8423-db0a-4037-a4cf-f79c60cb67a5"
+  id = "6670617d-e72a-47f5-a84c-693817ab4860"
 }
 ```
 

--- a/docs/data-sources/requests.md
+++ b/docs/data-sources/requests.md
@@ -14,9 +14,9 @@ Requests DataSource
 
 ```terraform
 data "opal_requests" "my_requests" {
-  cursor            = "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw"
+  cursor            = "eyJjcmVhdGVkX2F0IjoiMjAyMS0wMS0wNlQyMDo0NzowMFoiLCJ2YWx1ZSI6ImFkbWluIn0="
   page_size         = 200
-  show_pending_only = true
+  show_pending_only = false
 }
 ```
 

--- a/docs/data-sources/tag.md
+++ b/docs/data-sources/tag.md
@@ -14,7 +14,7 @@ Tag DataSource
 
 ```terraform
 data "opal_tag" "my_tag" {
-  id = "1b978423-db0a-4037-a4cf-f79c60cb67b3"
+  id = "f290a738-5f9f-43c2-ad67-fa31ff0eb946"
 }
 ```
 

--- a/docs/data-sources/uar.md
+++ b/docs/data-sources/uar.md
@@ -14,7 +14,7 @@ Uar DataSource
 
 ```terraform
 data "opal_uar" "my_uar" {
-  uar_id = "4baf8423-db0a-4037-a4cf-f79c60cb67a5"
+  uar_id = "f454d283-ca87-4a8a-bdbb-df212eca5353"
 }
 ```
 

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -15,7 +15,7 @@ User DataSource
 ```terraform
 data "opal_user" "my_user" {
   email = "johndoe@domain.org"
-  id    = "32acc112-21ff-4669-91c2-21e27683eaa1"
+  id    = "h0z968412-2451-4bbd-42h4-057l715d917m"
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     opal = {
       source  = "opalsecurity/opal"
-      version = "0.24.0"
+      version = "0.24.1"
     }
   }
 }

--- a/docs/resources/configuration_template.md
+++ b/docs/resources/configuration_template.md
@@ -22,7 +22,7 @@ resource "opal_configuration_template" "my_configurationtemplate" {
             auto_approval = false
             condition = {
                 group_ids = {
-                    "bc928154-552e-430c-848b-8c2b5ed5f0cf",
+                    "8154552e-30c0-448b-8c2b-5ed5f0cf07c6",
                 }
                 role_remote_ids = {
                     "...",
@@ -38,7 +38,7 @@ resource "opal_configuration_template" "my_configurationtemplate" {
                 {
                     operator = "AND"
                     owner_ids = {
-                        "49098c56-2b97-4419-b360-edc1d66b24bf",
+                        "7419b360-edc1-4d66-b24b-f8cfb72161b2",
                     }
                     require_admin_approval = false
                     require_manager_approval = false
@@ -51,7 +51,7 @@ resource "opal_configuration_template" "my_configurationtemplate" {
             visibility = {
         visibility = "GLOBAL"
         visibility_group_ids = {
-            "72161b24-a4a5-4fe0-9a5b-24ee84a3fbf4",
+            "a5b24ee8-4a3f-4bf4-9cbc-cae3a741f65f",
         }
     }
         }

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -16,14 +16,14 @@ Group Resource
 resource "opal_group" "my_group" {
     admin_owner_id = "7c86c85d-0651-43e2-a748-d69d658418e8"
             app_id = "f454d283-ca87-4a8a-bdbb-df212eca5353"
-            description = "Engineering team Okta group."
+            description = "This group represents Active Directory group \"Payments Production Admin\". We use this AD group to facilitate staging deployments and qualifying new releases."
             group_type = "OPAL_GROUP"
             message_channel_ids = {
-        "931861ef-161b-454f-b189-8e51c0009dd6",
+        "e51c0009-dd65-4b4e-90c4-2893326c8d3b",
     }
-            name = "mongo-db-prod"
+            name = "api-group"
             on_call_schedule_ids = {
-        "c4289332-6c8d-43b6-943a-d1053f385d17",
+        "1053f385-d17c-4e27-958f-256147d92ea2",
     }
             request_configurations = [
         {
@@ -31,7 +31,7 @@ resource "opal_group" "my_group" {
             auto_approval = false
             condition = {
                 group_ids = {
-                    "27d58f25-6147-4d92-aa24-6933c124e146",
+                    "3c124e14-6eb0-45cd-86c1-6b8673554554",
                 }
                 role_remote_ids = {
                     "...",
@@ -47,7 +47,7 @@ resource "opal_group" "my_group" {
                 {
                     operator = "AND"
                     owner_ids = {
-                        "ec25e287-06e5-40ad-a559-d94490f51937",
+                        "37d5bf18-869a-4e72-ac0c-c018ec506c2a",
                     }
                     require_admin_approval = false
                     require_manager_approval = false

--- a/docs/resources/on_call_schedule.md
+++ b/docs/resources/on_call_schedule.md
@@ -14,7 +14,7 @@ OnCallSchedule Resource
 
 ```terraform
 resource "opal_on_call_schedule" "my_oncallschedule" {
-  remote_id            = "PNZNINN"
+  remote_id            = "P7OWH2R"
   third_party_provider = "PAGER_DUTY"
 }
 ```

--- a/docs/resources/owner.md
+++ b/docs/resources/owner.md
@@ -20,7 +20,7 @@ resource "opal_owner" "my_owner" {
             reviewer_message_channel_id = "37cb7e41-12ba-46da-92ff-030abe0450b1"
             source_group_id = "1b978423-db0a-4037-a4cf-f79c60cb67b3"
             user_ids = {
-        "d056b2fc-18e8-4c3c-9f83-f4e778f2db42",
+        "8ae88222-a7d9-4bb5-b1a6-20906bed0335",
     }
         }
 ```

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -16,15 +16,15 @@ Resource Resource
 resource "opal_resource" "my_resource" {
     admin_owner_id = "7c86c85d-0651-43e2-a748-d69d658418e8"
             app_id = "f454d283-ca87-4a8a-bdbb-df212eca5353"
-            description = "Engineering team Okta role."
-            name = "mongo-db-prod"
+            description = "This resource represents AWS IAM role \"SupportUser\"."
+            name = "my-mongo-db"
             request_configurations = [
         {
             allow_requests = true
             auto_approval = false
             condition = {
                 group_ids = {
-                    "ed1f8f1d-8935-4bb4-bec8-046cdd06b0b3",
+                    "caf8a4c7-ec57-4b81-a172-8cd3687b3ad9",
                 }
                 role_remote_ids = {
                     "...",
@@ -40,7 +40,7 @@ resource "opal_resource" "my_resource" {
                 {
                     operator = "AND"
                     owner_ids = {
-                        "7b816172-8cd3-4687-b3ad-9a192be13afb",
+                        "66c2bdfc-b3e7-4464-ae94-bc89fbd03a92",
                     }
                     require_admin_approval = false
                     require_manager_approval = false
@@ -53,7 +53,7 @@ resource "opal_resource" "my_resource" {
             resource_type = "AWS_IAM_ROLE"
             visibility = "GLOBAL"
             visibility_group_ids = {
-        "85fd0c38-7f2b-431c-9922-ce15f950966c",
+        "dda2041a-0d76-41a9-b988-b1ee194539e3",
     }
         }
 ```

--- a/docs/resources/tag.md
+++ b/docs/resources/tag.md
@@ -14,8 +14,8 @@ Tag Resource
 
 ```terraform
 resource "opal_tag" "my_tag" {
-  key   = "api-scope"
-  value = "production"
+  key   = "database-name"
+  value = "redis_db"
 }
 ```
 

--- a/examples/data-sources/opal_group/data-source.tf
+++ b/examples/data-sources/opal_group/data-source.tf
@@ -1,3 +1,3 @@
 data "opal_group" "my_group" {
-  id = "32acc112-21ff-4669-91c2-21e27683eaa1"
+  id = "f454d283-ca87-4a8a-bdbb-df212eca5353"
 }

--- a/examples/data-sources/opal_message_channel/data-source.tf
+++ b/examples/data-sources/opal_message_channel/data-source.tf
@@ -1,3 +1,3 @@
 data "opal_message_channel" "my_messagechannel" {
-  id = "4baf8423-db0a-4037-a4cf-f79c60cb67a5"
+  id = "6670617d-e72a-47f5-a84c-693817ab4860"
 }

--- a/examples/data-sources/opal_requests/data-source.tf
+++ b/examples/data-sources/opal_requests/data-source.tf
@@ -1,5 +1,5 @@
 data "opal_requests" "my_requests" {
-  cursor            = "cD0yMDIxLTAxLTA2KzAzJTNBMjQlM0E1My40MzQzMjYlMkIwMCUzQTAw"
+  cursor            = "eyJjcmVhdGVkX2F0IjoiMjAyMS0wMS0wNlQyMDo0NzowMFoiLCJ2YWx1ZSI6ImFkbWluIn0="
   page_size         = 200
-  show_pending_only = true
+  show_pending_only = false
 }

--- a/examples/data-sources/opal_tag/data-source.tf
+++ b/examples/data-sources/opal_tag/data-source.tf
@@ -1,3 +1,3 @@
 data "opal_tag" "my_tag" {
-  id = "1b978423-db0a-4037-a4cf-f79c60cb67b3"
+  id = "f290a738-5f9f-43c2-ad67-fa31ff0eb946"
 }

--- a/examples/data-sources/opal_uar/data-source.tf
+++ b/examples/data-sources/opal_uar/data-source.tf
@@ -1,3 +1,3 @@
 data "opal_uar" "my_uar" {
-  uar_id = "4baf8423-db0a-4037-a4cf-f79c60cb67a5"
+  uar_id = "f454d283-ca87-4a8a-bdbb-df212eca5353"
 }

--- a/examples/data-sources/opal_user/data-source.tf
+++ b/examples/data-sources/opal_user/data-source.tf
@@ -1,4 +1,4 @@
 data "opal_user" "my_user" {
   email = "johndoe@domain.org"
-  id    = "32acc112-21ff-4669-91c2-21e27683eaa1"
+  id    = "h0z968412-2451-4bbd-42h4-057l715d917m"
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     opal = {
       source  = "opalsecurity/opal"
-      version = "0.24.0"
+      version = "0.24.1"
     }
   }
 }

--- a/examples/resources/opal_configuration_template/resource.tf
+++ b/examples/resources/opal_configuration_template/resource.tf
@@ -7,7 +7,7 @@ resource "opal_configuration_template" "my_configurationtemplate" {
             auto_approval = false
             condition = {
                 group_ids = {
-                    "bc928154-552e-430c-848b-8c2b5ed5f0cf",
+                    "8154552e-30c0-448b-8c2b-5ed5f0cf07c6",
                 }
                 role_remote_ids = {
                     "...",
@@ -23,7 +23,7 @@ resource "opal_configuration_template" "my_configurationtemplate" {
                 {
                     operator = "AND"
                     owner_ids = {
-                        "49098c56-2b97-4419-b360-edc1d66b24bf",
+                        "7419b360-edc1-4d66-b24b-f8cfb72161b2",
                     }
                     require_admin_approval = false
                     require_manager_approval = false
@@ -36,7 +36,7 @@ resource "opal_configuration_template" "my_configurationtemplate" {
             visibility = {
         visibility = "GLOBAL"
         visibility_group_ids = {
-            "72161b24-a4a5-4fe0-9a5b-24ee84a3fbf4",
+            "a5b24ee8-4a3f-4bf4-9cbc-cae3a741f65f",
         }
     }
         }

--- a/examples/resources/opal_group/resource.tf
+++ b/examples/resources/opal_group/resource.tf
@@ -1,14 +1,14 @@
 resource "opal_group" "my_group" {
     admin_owner_id = "7c86c85d-0651-43e2-a748-d69d658418e8"
             app_id = "f454d283-ca87-4a8a-bdbb-df212eca5353"
-            description = "Engineering team Okta group."
+            description = "This group represents Active Directory group \"Payments Production Admin\". We use this AD group to facilitate staging deployments and qualifying new releases."
             group_type = "OPAL_GROUP"
             message_channel_ids = {
-        "931861ef-161b-454f-b189-8e51c0009dd6",
+        "e51c0009-dd65-4b4e-90c4-2893326c8d3b",
     }
-            name = "mongo-db-prod"
+            name = "api-group"
             on_call_schedule_ids = {
-        "c4289332-6c8d-43b6-943a-d1053f385d17",
+        "1053f385-d17c-4e27-958f-256147d92ea2",
     }
             request_configurations = [
         {
@@ -16,7 +16,7 @@ resource "opal_group" "my_group" {
             auto_approval = false
             condition = {
                 group_ids = {
-                    "27d58f25-6147-4d92-aa24-6933c124e146",
+                    "3c124e14-6eb0-45cd-86c1-6b8673554554",
                 }
                 role_remote_ids = {
                     "...",
@@ -32,7 +32,7 @@ resource "opal_group" "my_group" {
                 {
                     operator = "AND"
                     owner_ids = {
-                        "ec25e287-06e5-40ad-a559-d94490f51937",
+                        "37d5bf18-869a-4e72-ac0c-c018ec506c2a",
                     }
                     require_admin_approval = false
                     require_manager_approval = false

--- a/examples/resources/opal_on_call_schedule/resource.tf
+++ b/examples/resources/opal_on_call_schedule/resource.tf
@@ -1,4 +1,4 @@
 resource "opal_on_call_schedule" "my_oncallschedule" {
-  remote_id            = "PNZNINN"
+  remote_id            = "P7OWH2R"
   third_party_provider = "PAGER_DUTY"
 }

--- a/examples/resources/opal_owner/resource.tf
+++ b/examples/resources/opal_owner/resource.tf
@@ -5,6 +5,6 @@ resource "opal_owner" "my_owner" {
             reviewer_message_channel_id = "37cb7e41-12ba-46da-92ff-030abe0450b1"
             source_group_id = "1b978423-db0a-4037-a4cf-f79c60cb67b3"
             user_ids = {
-        "d056b2fc-18e8-4c3c-9f83-f4e778f2db42",
+        "8ae88222-a7d9-4bb5-b1a6-20906bed0335",
     }
         }

--- a/examples/resources/opal_resource/resource.tf
+++ b/examples/resources/opal_resource/resource.tf
@@ -1,15 +1,15 @@
 resource "opal_resource" "my_resource" {
     admin_owner_id = "7c86c85d-0651-43e2-a748-d69d658418e8"
             app_id = "f454d283-ca87-4a8a-bdbb-df212eca5353"
-            description = "Engineering team Okta role."
-            name = "mongo-db-prod"
+            description = "This resource represents AWS IAM role \"SupportUser\"."
+            name = "my-mongo-db"
             request_configurations = [
         {
             allow_requests = true
             auto_approval = false
             condition = {
                 group_ids = {
-                    "ed1f8f1d-8935-4bb4-bec8-046cdd06b0b3",
+                    "caf8a4c7-ec57-4b81-a172-8cd3687b3ad9",
                 }
                 role_remote_ids = {
                     "...",
@@ -25,7 +25,7 @@ resource "opal_resource" "my_resource" {
                 {
                     operator = "AND"
                     owner_ids = {
-                        "7b816172-8cd3-4687-b3ad-9a192be13afb",
+                        "66c2bdfc-b3e7-4464-ae94-bc89fbd03a92",
                     }
                     require_admin_approval = false
                     require_manager_approval = false
@@ -38,6 +38,6 @@ resource "opal_resource" "my_resource" {
             resource_type = "AWS_IAM_ROLE"
             visibility = "GLOBAL"
             visibility_group_ids = {
-        "85fd0c38-7f2b-431c-9922-ce15f950966c",
+        "dda2041a-0d76-41a9-b988-b1ee194539e3",
     }
         }

--- a/examples/resources/opal_tag/resource.tf
+++ b/examples/resources/opal_tag/resource.tf
@@ -1,4 +1,4 @@
 resource "opal_tag" "my_tag" {
-  key   = "api-scope"
-  value = "production"
+  key   = "database-name"
+  value = "redis_db"
 }

--- a/gen.yaml
+++ b/gen.yaml
@@ -11,7 +11,7 @@ generation:
     oAuth2ClientCredentialsEnabled: false
   flattenGlobalSecurity: true
 terraform:
-  version: 0.24.0
+  version: 0.24.1
   additionalDataSources: []
   additionalDependencies: {}
   additionalResources: []

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -211,6 +211,9 @@ func (r *GroupResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			},
 			"oncall_schedules": schema.SingleNestedAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.Object{
+					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
+				},
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -220,7 +223,10 @@ func (r *GroupResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 						Description: `The ID of the on-call schedule.`,
 					},
 					"name": schema.StringAttribute{
-						Computed:    true,
+						Computed: true,
+						PlanModifiers: []planmodifier.String{
+							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+						},
 						Description: `The name of the on call schedule.`,
 					},
 					"remote_id": schema.StringAttribute{
@@ -231,7 +237,10 @@ func (r *GroupResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 						Description: `The remote ID of the on call schedule`,
 					},
 					"third_party_provider": schema.StringAttribute{
-						Computed:    true,
+						Computed: true,
+						PlanModifiers: []planmodifier.String{
+							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+						},
 						Description: `The third party provider of the on call schedule. must be one of ["OPSGENIE", "PAGER_DUTY"]`,
 						Validators: []validator.String{
 							stringvalidator.OneOf(

--- a/internal/sdk/internal/utils/security.go
+++ b/internal/sdk/internal/utils/security.go
@@ -21,6 +21,7 @@ type securityTag struct {
 	Name    string
 	Type    string
 	SubType string
+	Env     string
 }
 
 func PopulateSecurity(ctx context.Context, req *http.Request, securitySource func(context.Context) (interface{}, error)) error {
@@ -227,6 +228,7 @@ func parseSecurityTag(field reflect.StructField) *securityTag {
 	name := ""
 	securityType := ""
 	securitySubType := ""
+	env := ""
 
 	options := strings.Split(tag, ",")
 	for _, optionConf := range options {
@@ -246,6 +248,8 @@ func parseSecurityTag(field reflect.StructField) *securityTag {
 			option = true
 		case "scheme":
 			scheme = true
+		case "env":
+			env = parts[1]
 		}
 	}
 
@@ -257,6 +261,7 @@ func parseSecurityTag(field reflect.StructField) *securityTag {
 		Name:    name,
 		Type:    securityType,
 		SubType: securitySubType,
+		Env:     env,
 	}
 }
 

--- a/internal/sdk/opalapi.go
+++ b/internal/sdk/opalapi.go
@@ -181,8 +181,8 @@ func New(opts ...SDKOption) *OpalAPI {
 			Language:          "go",
 			OpenAPIDocVersion: "1.0",
 			SDKVersion:        "0.0.1",
-			GenVersion:        "2.385.2",
-			UserAgent:         "speakeasy-sdk/go 0.0.1 2.385.2 1.0 github.com/opalsecurity/terraform-provider-opal/internal/sdk",
+			GenVersion:        "2.390.0",
+			UserAgent:         "speakeasy-sdk/go 0.0.1 2.390.0 1.0 github.com/opalsecurity/terraform-provider-opal/internal/sdk",
 			Hooks:             hooks.New(),
 		},
 	}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -549,6 +549,7 @@ paths:
                 allOf:
                   - $ref: "#/components/schemas/OnCallScheduleList"
                   - x-speakeasy-wrapped-attribute: "oncall_schedules"
+                  - x-speakeasy-param-suppress-computed-diff: true
           description: The on call schedules attached to the group.
         "404":
           description: Not Found

--- a/terraform_overlay.yaml
+++ b/terraform_overlay.yaml
@@ -143,6 +143,7 @@ actions:
       allOf:
         - $ref: "#/components/schemas/OnCallScheduleList"
         - x-speakeasy-wrapped-attribute: "oncall_schedules"
+        - x-speakeasy-param-suppress-computed-diff: true
   - target: $["paths"]["/groups/{group_id}/on-call-schedules"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
     remove: true
   - target: $["paths"]["/groups/{group_id}/on-call-schedules"]["get"]


### PR DESCRIPTION
## Description of the change
If anything changes in the plan for a group, it prints the output of the oncall_schedules field as known after apply. It's actually just a field updated from a GET during state refresh so it cannot change from our end so we should mark it as computed to suppress output.

> Write a brief description of your change here. 

## Checklist

- [ ] I performed a self-review of my code
- [x] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
