### PR TITLE
Suppress admin_owner_id, description, and group_leader_user_ids on op…

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: b5c8bf75-06e1-47c8-b9ae-ce49ba56069d
 management:
-  docChecksum: 5daed4c9f71bbd24fb1edcfc76773b3e
+  docChecksum: c526a5c16371a9fbee904b84c7f529df
   docVersion: "1.0"
-  speakeasyVersion: 1.357.2
-  generationVersion: 2.390.0
-  releaseVersion: 0.24.1
-  configChecksum: 9e09c53a463983648dfa0e1093924754
+  speakeasyVersion: 1.357.4
+  generationVersion: 2.390.6
+  releaseVersion: 0.24.2
+  configChecksum: 640ca66da959ad667e6f475206a8907d
   repoURL: https://github.com/opalsecurity/terraform-provider-opal.git
   repoSubDirectory: .
   published: true

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,17 +1,17 @@
-speakeasyVersion: 1.357.2
+speakeasyVersion: 1.357.4
 sources:
     opal-terraform-provider:
         sourceNamespace: opal-terraform-provider
-        sourceRevisionDigest: sha256:d02e1065ee2374fe3473e6c0012efe2bbc61bc5714057a82b9b83becfecf8605
-        sourceBlobDigest: sha256:f40cfb942fb5f591ee72e7733b91d943a26f39f106e1c8d976027a0d83e493f7
+        sourceRevisionDigest: sha256:188341015e92c3c31882090012e878f80e7f2f4d410f86bc7f76096964a58c1b
+        sourceBlobDigest: sha256:2428708c8d1a4386f312815ae36ee497d830d0576f03fa36db3b1a339c88bc86
         tags:
             - latest
 targets:
     terraform:
         source: opal-terraform-provider
         sourceNamespace: opal-terraform-provider
-        sourceRevisionDigest: sha256:d02e1065ee2374fe3473e6c0012efe2bbc61bc5714057a82b9b83becfecf8605
-        sourceBlobDigest: sha256:f40cfb942fb5f591ee72e7733b91d943a26f39f106e1c8d976027a0d83e493f7
+        sourceRevisionDigest: sha256:188341015e92c3c31882090012e878f80e7f2f4d410f86bc7f76096964a58c1b
+        sourceBlobDigest: sha256:2428708c8d1a4386f312815ae36ee497d830d0576f03fa36db3b1a339c88bc86
         outLocation: .
 workflow:
     workflowVersion: 1.0.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     opal = {
       source  = "opalsecurity/opal"
-      version = "0.24.1"
+      version = "0.24.2"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     opal = {
       source  = "opalsecurity/opal"
-      version = "0.24.1"
+      version = "0.24.2"
     }
   }
 }

--- a/gen.yaml
+++ b/gen.yaml
@@ -11,7 +11,7 @@ generation:
     oAuth2ClientCredentialsEnabled: false
   flattenGlobalSecurity: true
 terraform:
-  version: 0.24.1
+  version: 0.24.2
   additionalDataSources: []
   additionalDependencies: {}
   additionalResources: []

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -19,6 +19,7 @@ import (
 	speakeasy_boolplanmodifier "github.com/opalsecurity/terraform-provider-opal/internal/planmodifiers/boolplanmodifier"
 	speakeasy_listplanmodifier "github.com/opalsecurity/terraform-provider-opal/internal/planmodifiers/listplanmodifier"
 	speakeasy_objectplanmodifier "github.com/opalsecurity/terraform-provider-opal/internal/planmodifiers/objectplanmodifier"
+	speakeasy_setplanmodifier "github.com/opalsecurity/terraform-provider-opal/internal/planmodifiers/setplanmodifier"
 	speakeasy_stringplanmodifier "github.com/opalsecurity/terraform-provider-opal/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/opalsecurity/terraform-provider-opal/internal/provider/types"
 	"github.com/opalsecurity/terraform-provider-opal/internal/sdk"
@@ -78,7 +79,10 @@ func (r *GroupResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"admin_owner_id": schema.StringAttribute{
-				Computed:    true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+				},
 				Optional:    true,
 				Description: `The ID of the owner of the group.`,
 			},
@@ -91,7 +95,10 @@ func (r *GroupResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Description: `The ID of the app for the group. Requires replacement if changed. `,
 			},
 			"description": schema.StringAttribute{
-				Computed:    true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+				},
 				Optional:    true,
 				Description: `A description of the remote group.`,
 			},
@@ -103,7 +110,10 @@ func (r *GroupResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Description: `The ID of the associated group binding.`,
 			},
 			"group_leader_user_ids": schema.SetAttribute{
-				Computed:    true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Set{
+					speakeasy_setplanmodifier.SuppressDiff(speakeasy_setplanmodifier.ExplicitSuppress),
+				},
 				Optional:    true,
 				ElementType: types.StringType,
 				Description: `A list of User IDs for the group leaders of the group`,

--- a/internal/sdk/opalapi.go
+++ b/internal/sdk/opalapi.go
@@ -181,8 +181,8 @@ func New(opts ...SDKOption) *OpalAPI {
 			Language:          "go",
 			OpenAPIDocVersion: "1.0",
 			SDKVersion:        "0.0.1",
-			GenVersion:        "2.390.0",
-			UserAgent:         "speakeasy-sdk/go 0.0.1 2.390.0 1.0 github.com/opalsecurity/terraform-provider-opal/internal/sdk",
+			GenVersion:        "2.390.6",
+			UserAgent:         "speakeasy-sdk/go 0.0.1 2.390.6 1.0 github.com/opalsecurity/terraform-provider-opal/internal/sdk",
 			Hooks:             hooks.New(),
 		},
 	}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4093,11 +4093,13 @@ components:
           description: A description of the group.
           example: This group represents Active Directory group "Payments Production Admin". We use this AD group to facilitate staging deployments and qualifying new releases.
           type: string
+          x-speakeasy-param-suppress-computed-diff: true
         admin_owner_id:
           description: The ID of the owner of the group.
           example: 7c86c85d-0651-43e2-a748-d69d658418e8
           format: uuid
           type: string
+          x-speakeasy-param-suppress-computed-diff: true
         max_duration:
           description: The maximum duration for which the group can be requested (in minutes). Use -1 to set to indefinite. Deprecated in favor of `request_configurations`.
           type: integer
@@ -4171,6 +4173,7 @@ components:
             format: uuid
           type: array
           format: set
+          x-speakeasy-param-suppress-computed-diff: true
         request_configurations:
           type: array
           items:

--- a/terraform_overlay.yaml
+++ b/terraform_overlay.yaml
@@ -1564,6 +1564,15 @@ actions:
   - target: $["components"]["schemas"]["PaginatedConfigurationTemplateList"]
     update:
       x-speakeasy-entity: ConfigurationTemplateList
+  - target: $["components"]["schemas"]["UpdateGroupInfo"]["properties"]["admin_owner_id"]
+    update:
+      x-speakeasy-param-suppress-computed-diff: true
+  - target: $["components"]["schemas"]["UpdateGroupInfo"]["properties"]["description"]
+    update:
+      x-speakeasy-param-suppress-computed-diff: true
+  - target: $["components"]["schemas"]["UpdateGroupInfo"]["properties"]["group_leader_user_ids"]
+    update:
+      x-speakeasy-param-suppress-computed-diff: true
   - target: $
     update:
       x-speakeasy-retries:


### PR DESCRIPTION
…al_group

## Description of the change
By adding x-speakeasy-param-suppress-computed-diff: true, if the value is not provided in the terraform block itself, the terraform plan validator will not output the "known after apply" statement. This is useful for the cases where someone wants to not set a value and let it continue having the old value for optional arguments. But if they do provide the value in the block that value will be sent.

> Write a brief description of your change here. 

## Checklist

- [ ] I performed a self-review of my code
- [x] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
