### PR TITLE
[COR-1451] Update custom validator to use correct field names

### DIFF
--- a/internal/validators/listvalidators/request_configurations.go
+++ b/internal/validators/listvalidators/request_configurations.go
@@ -62,7 +62,7 @@ func (v ListRequestConfigurationsValidator) ValidateList(ctx context.Context, re
 		if !(hasReviewerStages || isAutoApprove || isNotRequestable) {
 			resp.Diagnostics.Append(validatordiag.InvalidAttributeTypeDiagnostic(
 				req.Path,
-				"invalid request configuration. Please specify a reviewer_stage, set auto_approve to true, or set is_requestable to false",
+				"invalid request configuration. Please specify a reviewer_stage, set auto_approval to true, or set allow_requests to false",
 				req.Path.String()+": "+v.Description(ctx),
 			))
 		}

--- a/internal/validators/setvalidators/request_configurations.go
+++ b/internal/validators/setvalidators/request_configurations.go
@@ -63,7 +63,7 @@ func (v SetRequestConfigurationsValidator) ValidateSet(ctx context.Context, req 
 		if !(hasReviewerStages || isAutoApprove || isNotRequestable) {
 			resp.Diagnostics.Append(validatordiag.InvalidAttributeTypeDiagnostic(
 				req.Path,
-				"invalid request configuration. Please specify a reviewer_stage, set auto_approve to true, or set is_requestable to false",
+				"invalid request configuration. Please specify a reviewer_stage, set auto_approval to true, or set allow_requests to false",
 				req.Path.String()+": "+v.Description(ctx),
 			))
 		}


### PR DESCRIPTION
## Description of the change
Validators were using the old field names, this PR corrects that.

## Checklist
- [x] I performed a self-review of my code
- [ ] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
