### PR TITLE
[COR-1630] Include custom_request_notification in stateupgraders

### DIFF
--- a/internal/stateupgraders/group_v0.go
+++ b/internal/stateupgraders/group_v0.go
@@ -56,6 +56,7 @@ func GroupStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest,
 					"require_manager_approval": tftypes.Bool,
 					"reviewer": tftypes.Set{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{"id": tftypes.String}}},
 				}}},
+				"custom_request_notification": tftypes.String,
 			}}},
 		},
 	}
@@ -115,6 +116,7 @@ func GroupStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest,
 			"require_manager_approval": tftypes.Bool,
 			"reviewer": tftypes.Set{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{"id": tftypes.String}}},
 		}}},
+		"custom_request_notification": tftypes.String,
 	}}}
 
 	var GroupV3 = tftypes.Object{

--- a/internal/stateupgraders/resource_v0.go
+++ b/internal/stateupgraders/resource_v0.go
@@ -70,6 +70,7 @@ func ResourceStateUpgraderV0(ctx context.Context, req resource.UpgradeStateReque
 					"require_manager_approval": tftypes.Bool,
 					"reviewer": tftypes.Set{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{"id": tftypes.String}}},
 				}}},
+				"custom_request_notification": tftypes.String,
 			}}},
 		},
 	}
@@ -89,6 +90,7 @@ func ResourceStateUpgraderV0(ctx context.Context, req resource.UpgradeStateReque
 			"require_manager_approval": tftypes.Bool,
 			"reviewer": tftypes.Set{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{"id": tftypes.String}}},
 		}}},
+		"custom_request_notification": tftypes.String,
 	}}}
 
 	var ticketPropagationType = tftypes.Object{


### PR DESCRIPTION
## Description of the change
We need to add the new `custom_request_notification` field in groups and resources in the state upgrader file to ensure there are no breaking changes when upgrading.
https://github.com/opalsecurity/terraform-provider-opal/pull/88

## Checklist

- [ ] I performed a self-review of my code
- [ ] I manually tested my code change (please list details in description)
- [ ] I added unit tests 
- [ ] I updated the changelog
- [ ] I updated the public facing docs
