### PR TITLE
Release v3.5.3: ship v2→v3 state-upgrader fix (#194)

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,7 +5,7 @@ management:
   docVersion: "1.0"
   speakeasyVersion: 1.763.0
   generationVersion: 2.884.0
-  releaseVersion: 3.5.2
+  releaseVersion: 3.5.3
   configChecksum: 7e6913ae6e4e14190834fea4a6737205
   repoURL: https://github.com/opalsecurity/terraform-provider-opal.git
   repoSubDirectory: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v3.5.3
+ - Fixes the v2→v3 state upgraders for `opal_group` and `opal_resource` so that state written by provider 2.x upgrades directly to the current release in one hop, instead of failing with `Unable to Upgrade Resource State ... error decoding object`. The upgraders now emit every current top-level schema attribute (previously drifted, missing `extensions_duration_in_minutes`, `last_successful_sync`, `ancestor_resource_ids`, and `descendant_resource_ids`). No intermediate version step is required.
+
 ## v3.5.2
  - Adds `attribute_selectors` field to `opal_access_rule` rule clauses
  - Adds support for GitHub Enterprise Org level teams: `org_name` can now be specified on `github_team` remote info to target teams in an enterprise-managed GitHub organization


### PR DESCRIPTION
## Description of the change

Cuts provider release **v3.5.3** so the state-upgrader fix from #194 (already merged to `main`, Linear [EPRD-2607](https://linear.app/opalsecurity/issue/EPRD-2607)) actually ships to the Terraform Registry.

**Background:** #194 fixed the drifted v0→v1 state upgraders for `opal_group`/`opal_resource` (they emitted fewer attributes than the current schema, causing `Unable to Upgrade Resource State … error decoding object; expected 23 attributes, got 21` when upgrading 2.x state past v3.0.16). But #194 left `.speakeasy/gen.lock` `releaseVersion` at `3.5.2`, so the Release workflow never fired and no new provider was published. The customer (Blend) still has to hop through the `3.0.8` intermediate.

**What this PR does:**
- Bumps `.speakeasy/gen.lock` `management.releaseVersion` `3.5.2` → `3.5.3`. `release.yml` reads exactly this value (`yq '.management.releaseVersion'`) to create the `v3.5.3` tag and publish via GoReleaser when this lands on `main`.
- Adds the `v3.5.3` entry to `CHANGELOG.md` (the "update the changelog" step #194 left unchecked).

This ships **exactly the current `main`** (which already carries #194) as 3.5.3 — no regeneration, no unrelated spec changes. The `internal/stateupgraders/*.go` files are hand-maintained and not tracked in `gen.lock`, so the fix is already present on `main` and needs no code change here. This follows the same hand-authored version-bump pattern as prior fix releases (e.g. #183 → 3.4.3, #185 → 3.5.0).

Once merged, Blend can upgrade prod directly `2.0.1` → `3.5.3` without the intermediate `3.0.8` step.

## Checklist

- [x] I performed a self-review of my code
- [x] I manually tested my code change (verified `yq '.management.releaseVersion' .speakeasy/gen.lock` resolves to `3.5.3`, the value `release.yml` tags from; the upgrader fix itself was tested in #194)
- [ ] I added unit tests (N/A — version/changelog only; regression tests were added in #194)
- [x] I updated the changelog
- [ ] I updated the public facing docs (N/A — no schema/API surface change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsRSg85q1ZwDo5dWhhkBRL)_