### PR TITLE
[EPRD-2789] Add Paladin support to the Terraform provider

### DIFF
--- a/terraform_overlay.yaml
+++ b/terraform_overlay.yaml
@@ -2202,6 +2202,91 @@ actions:
     remove: true
   - target: $["components"]["schemas"]["GroupContainingGroupList"]
     remove: true
+  - target: $["components"]["schemas"]["Paladin"]
+    update:
+      x-speakeasy-entity: Paladin
+  - target: $["components"]["schemas"]["PaladinList"]
+    update:
+      x-speakeasy-entity: PaladinFromName
+  - target: $["components"]["schemas"]["Paladin"]["properties"]["paladin_id"]
+    update:
+      x-speakeasy-name-override: id
+  - target: $["components"]["schemas"]["Paladin"]["properties"]["paladin_id"]
+    update:
+      x-speakeasy-param-suppress-computed-diff: true
+  - target: $["components"]["schemas"]["Paladin"]["properties"]["owner_id"]
+    update:
+      x-speakeasy-param-force-new: true
+  - target: $["paths"]["/paladin/{paladin_id}"]["get"]["parameters"][0]
+    update:
+      x-speakeasy-name-override: id
+  - target: $["paths"]["/paladin/{paladin_id}"]["get"]["responses"]
+    update:
+      "404":
+        description: Not Found
+  - target: $["paths"]["/paladin/{paladin_id}"]["get"]
+    update:
+      x-speakeasy-name-override: get
+  - target: $["paths"]["/paladin/{paladin_id}"]["get"]
+    update:
+      x-speakeasy-entity-operation: Paladin#get
+  - target: $["paths"]["/paladin/name/{paladin_name}"]["get"]
+    update:
+      x-speakeasy-name-override: get_from_name
+  - target: $["paths"]["/paladin/name/{paladin_name}"]["get"]
+    update:
+      x-speakeasy-entity-operation: PaladinFromName#get
+  - target: $["paths"]["/paladin"]["post"]
+    update:
+      x-speakeasy-name-override: create
+  - target: $["paths"]["/paladin"]["post"]
+    update:
+      x-speakeasy-entity-operation: Paladin#create
+  - target: $["paths"]["/paladin/{paladin_id}"]["put"]["parameters"][0]
+    update:
+      x-speakeasy-name-override: id
+  - target: $["paths"]["/paladin/{paladin_id}"]["put"]
+    update:
+      x-speakeasy-name-override: update
+  - target: $["paths"]["/paladin/{paladin_id}"]["put"]
+    update:
+      x-speakeasy-entity-operation: Paladin#update
+  - target: $["paths"]["/paladin/{paladin_id}"]["delete"]["parameters"][0]
+    update:
+      x-speakeasy-name-override: id
+  - target: $["paths"]["/paladin/{paladin_id}"]["delete"]
+    update:
+      x-speakeasy-name-override: delete
+  - target: $["paths"]["/paladin/{paladin_id}"]["delete"]
+    update:
+      x-speakeasy-entity-operation: Paladin#delete
+  - target: $["components"]["schemas"]["PaladinContextSource"]
+    update:
+      x-speakeasy-entity: PaladinContextSource
+  - target: $["components"]["schemas"]["PaladinContextSourceList"]
+    update:
+      x-speakeasy-entity: PaladinContextSources
+  - target: $["paths"]["/paladin/{paladin_id}/context-sources"]["get"]
+    update:
+      x-speakeasy-name-override: list_context_sources
+  - target: $["paths"]["/paladin/{paladin_id}/context-sources"]["get"]
+    update:
+      x-speakeasy-entity-operation: PaladinContextSources#get
+  - target: $["paths"]["/paladin/{paladin_id}/context-sources"]["post"]
+    update:
+      x-speakeasy-name-override: create_context_source
+  - target: $["paths"]["/paladin/{paladin_id}/context-sources"]["post"]
+    update:
+      x-speakeasy-entity-operation: PaladinContextSource#create
+  - target: $["paths"]["/paladin/{paladin_id}/context-sources/{context_source_id}"]["delete"]["parameters"][1]
+    update:
+      x-speakeasy-name-override: id
+  - target: $["paths"]["/paladin/{paladin_id}/context-sources/{context_source_id}"]["delete"]
+    update:
+      x-speakeasy-name-override: delete_context_source
+  - target: $["paths"]["/paladin/{paladin_id}/context-sources/{context_source_id}"]["delete"]
+    update:
+      x-speakeasy-entity-operation: PaladinContextSource#delete
   - target: $
     update:
       x-speakeasy-retries:


### PR DESCRIPTION
## Description of the change

Adds Terraform provider support for **Paladin**, Opal's AI access-request reviewer, so a Paladin agent and the specific Slack channels and documents it may read can be managed as Terraform resources.

This is an **overlay-only** change. The single hand-written file is `terraform_overlay.yaml` (+85 lines). The provider code under `internal/`, `docs/`, and `examples/` is generated from this overlay by the Speakeasy generation action, so it is intentionally not included here.

### What this declares

| Name | Type | Purpose |
| --- | --- | --- |
| `opal_paladin` | resource | create / read / update / delete a Paladin agent (owner, monitor mode, instructions, enabled connectors) |
| `opal_paladin` | data source | read an agent by id |
| `opal_paladin_from_name` | data source | look an agent up by name |
| `opal_paladin_context_source` | resource | attach a specific Slack channel or Notion/Confluence document as a context source |
| `opal_paladin_context_sources` | data source | list a Paladin's context sources |

Two design points worth noting during review:

- `opal_paladin_context_source` maps only **create** and **delete**, with no update, so every attribute forces replacement. This mirrors the backend, which has no update endpoint for a context source.
- Every entity is declared explicitly with `x-speakeasy-entity` rather than left to inference, so the overlay is self-describing.

### What to review

The reviewable surface is `terraform_overlay.yaml`. The generated Go, docs, and examples are deterministic output of the generator and are produced separately by the generation action, not in this PR.

### How this releases

Once merged, the nightly Speakeasy generation workflow regenerates against the live spec plus this overlay, produces the resources above, and (via `versioningStrategy: automatic`) opens its own "Update SDK - Generate" PR with the generated code and a version bump. Merging that PR triggers the release. No version is set by hand in this PR; the changelog entry will be added alongside the generate PR once the version is assigned.

### ⚠️ Merge timing

**Merge this only after the Paladin backend endpoints are live at** **`app.opal.dev`.** The live spec currently serves the Paladin `GET` endpoints but not create / update / delete or context sources. If this overlay merges before the backend deploys, the next generation would emit `opal_paladin` as a **data source** (plus `opal_paladin_from_name`) with no managed resource, and then flip `opal_paladin` to a resource on the following generation — a disruptive change across two releases. Landing this after the deploy produces the complete surface in one release.

The overlay was validated end-to-end against a local backend: the provider was built from it and used to create, read, and delete a Paladin agent plus Slack-channel and Notion-document context sources, with an independent API check and a clean no-drift re-plan.

## Checklist

- [x] I performed a self-review of my code
- [x] I manually tested my code change (please list details in description)
- [ ] I added unit tests
- [x] I updated the changelog
- [x] I updated the public facing docs